### PR TITLE
Add AwaitingLegalAdvisor state to the Petitioner retrieve case list

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CaseRetrievalStateMap.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CaseRetrievalStateMap.java
@@ -30,7 +30,8 @@ public class CaseRetrievalStateMap {
                 CaseState.AOS_STARTED,
                 CaseState.AOS_COMPLETED,
                 CaseState.AOS_SUBMITTED_AWAITING_ANSWER,
-                CaseState.AWAITING_DECREE_NISI)
+                CaseState.AWAITING_DECREE_NISI,
+                CaseState.AWAITING_LEGAL_ADVISOR_REFERRAL)
         );
 
     public static final Map<CaseStateGrouping, List<CaseState>> RESPONDENT_CASE_STATE_GROUPING =

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CaseRetrievalStateMapTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CaseRetrievalStateMapTest.java
@@ -23,7 +23,8 @@ public class CaseRetrievalStateMapTest {
                 CaseState.SUBMITTED,
                 CaseState.ISSUED,
                 CaseState.PENDING_REJECTION,
-                CaseState.AWAITING_DOCUMENTS
+                CaseState.AWAITING_DOCUMENTS,
+                CaseState.AWAITING_LEGAL_ADVISOR_REFERRAL
             );
     }
 


### PR DESCRIPTION
AwaitingLegalAdvisor state was missing from the Petitioner Retrieve State Map.
As such, retrieve-petition was returning 204 no case found for cases in AwaitingLegalAdvisor, the state after DN submission has occurred.
This is an issue since correct dynamic content on DN and redirection from D8 depends on the case being returned when its in the AwaitingLegalAdvisor state.