### PR TITLE
Retrieve Petition by CaseId for Citizen

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/petition/CcdRetrieveCaseByIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/petition/CcdRetrieveCaseByIdTest.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.divorce.petition;
+
+import io.restassured.response.Response;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+import uk.gov.hmcts.reform.divorce.model.UserDetails;
+import uk.gov.hmcts.reform.divorce.support.PetitionSupport;
+import uk.gov.hmcts.reform.divorce.util.ResourceLoader;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class CcdRetrieveCaseByIdTest extends PetitionSupport {
+
+    @Test
+    public void givenOneSubmittedCaseInCcd_whenRetrieveCase_thenReturnTheCase() throws Exception {
+        final String userToken = getUserToken();
+
+        Long caseId = getCaseIdFromSubmittingANewCase(userToken);
+
+        Response cmsResponse = retrieveCaseById(userToken, String.valueOf(caseId));
+
+        assertEquals(HttpStatus.OK.value(), cmsResponse.getStatusCode());
+        assertEquals(caseId, cmsResponse.path("id"));
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/PetitionSupport.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/PetitionSupport.java
@@ -23,10 +23,6 @@ public abstract class PetitionSupport extends CcdUpdateSupport {
     @Value("${case.maintenance.get-case.context-path}")
     private String getCaseContextPath;
 
-    @Value("${case.maintenance.retrieve-by-id.context-path}")
-    private String retrieveCaseByIdContextPath;
-
-
     protected Response saveDraft(String userToken, String fileName, Map<String, Object> params) throws Exception {
         return
             RestUtil.putToRestService(
@@ -67,7 +63,7 @@ public abstract class PetitionSupport extends CcdUpdateSupport {
     protected Response retrieveCaseById(String userToken, String caseId) {
         return
             RestUtil.getFromRestService(
-                getRetrieveCaseByIdRequestUrl() + "/" + caseId,
+                getCaseRequestUrl() + "/" + caseId,
                 getHeaders(userToken),
                 null
             );
@@ -102,6 +98,4 @@ public abstract class PetitionSupport extends CcdUpdateSupport {
     private String draftsRequestUrl() {
         return serverUrl + draftContextPath;
     }
-
-    private String getRetrieveCaseByIdRequestUrl() { return serverUrl + retrieveCaseByIdContextPath; }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/PetitionSupport.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/PetitionSupport.java
@@ -23,6 +23,9 @@ public abstract class PetitionSupport extends CcdUpdateSupport {
     @Value("${case.maintenance.get-case.context-path}")
     private String getCaseContextPath;
 
+    @Value("${case.maintenance.retrieve-by-id.context-path}")
+    private String retrieveCaseByIdContextPath;
+
 
     protected Response saveDraft(String userToken, String fileName, Map<String, Object> params) throws Exception {
         return
@@ -61,6 +64,15 @@ public abstract class PetitionSupport extends CcdUpdateSupport {
             );
     }
 
+    protected Response retrieveCaseById(String userToken, String caseId) {
+        return
+            RestUtil.getFromRestService(
+                getRetrieveCaseRequestUrl() + "/" + caseId,
+                getHeaders(userToken),
+                null
+            );
+    }
+
     protected Response getCase(String userToken) {
         return
             RestUtil.getFromRestService(
@@ -90,4 +102,6 @@ public abstract class PetitionSupport extends CcdUpdateSupport {
     private String draftsRequestUrl() {
         return serverUrl + draftContextPath;
     }
+
+    private String getRetrieveCaseByIdRequestUrl() { return serverUrl + retrieveCaseByIdContextPath; }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/PetitionSupport.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/PetitionSupport.java
@@ -67,7 +67,7 @@ public abstract class PetitionSupport extends CcdUpdateSupport {
     protected Response retrieveCaseById(String userToken, String caseId) {
         return
             RestUtil.getFromRestService(
-                getRetrieveCaseRequestUrl() + "/" + caseId,
+                getRetrieveCaseByIdRequestUrl() + "/" + caseId,
                 getHeaders(userToken),
                 null
             );

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -24,7 +24,6 @@ case.maintenance.draft.context-path=/casemaintenance/version/1/drafts
 case.maintenance.link-respondent.context-path=/casemaintenance/version/1/link-respondent
 case.maintenance.aos-case.context-path=/casemaintenance/version/1/retrieveAosCase
 case.maintenance.get-case.context-path=/casemaintenance/version/1/case
-case.maintenance.retrieve-by-id.context-path=/casemaintenance/version/1/retrieveCaseById
 
 idam.s2s-auth.url=${idam_s2s_url:http://rpe-service-auth-provider-aat.service.core-compute-aat.internal}
 auth.provider.ccdsubmission.microservice=divorce_ccd_submission

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -24,6 +24,7 @@ case.maintenance.draft.context-path=/casemaintenance/version/1/drafts
 case.maintenance.link-respondent.context-path=/casemaintenance/version/1/link-respondent
 case.maintenance.aos-case.context-path=/casemaintenance/version/1/retrieveAosCase
 case.maintenance.get-case.context-path=/casemaintenance/version/1/case
+case.maintenance.retrieve-by-id.context-path=/casemaintenance/version/1/retrieveCaseById
 
 idam.s2s-auth.url=${idam_s2s_url:http://rpe-service-auth-provider-aat.service.core-compute-aat.internal}
 auth.provider.ccdsubmission.microservice=divorce_ccd_submission

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/PetitionController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/PetitionController.java
@@ -13,6 +13,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -162,5 +163,22 @@ public class PetitionController {
                                                         @ApiParam(value = "JWT authorisation token issued by IDAM",
                                                             required = true)final String jwt) {
         return ResponseEntity.ok(petitionService.getAllDrafts(jwt));
+    }
+
+    @GetMapping(path = "/retrieveCaseById/{caseId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation(value = "Retrieve CCD case by CaseId")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "Returns case with CaseId"),
+        @ApiResponse(code = 404, message = "Returns case not found or not authorised to view")
+    })
+    public ResponseEntity<CaseDetails> retrieveCaseById(
+        @RequestHeader(HttpHeaders.AUTHORIZATION)
+        @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String jwt,
+        @PathVariable("caseId")
+        @ApiParam("Unique identifier of the session that was submitted to CCD") String caseId
+    ) {
+        CaseDetails retrievedCase = petitionService.retrievePetitionByCaseId(jwt, caseId);
+
+        return retrievedCase == null ? ResponseEntity.notFound().build() : ResponseEntity.ok(retrievedCase);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/PetitionController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/PetitionController.java
@@ -165,7 +165,7 @@ public class PetitionController {
         return ResponseEntity.ok(petitionService.getAllDrafts(jwt));
     }
 
-    @GetMapping(path = "/retrieveCaseById/{caseId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(path = "/case/{caseId}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Retrieve CCD case by CaseId")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "Returns case with CaseId"),

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/PetitionController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/PetitionController.java
@@ -170,7 +170,7 @@ public class PetitionController {
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "Returns case with CaseId"),
         @ApiResponse(code = 404, message = "Returns case not found or not authorised to view")
-    })
+        })
     public ResponseEntity<CaseDetails> retrieveCaseById(
         @RequestHeader(HttpHeaders.AUTHORIZATION)
         @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String jwt,

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/PetitionController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/PetitionController.java
@@ -177,8 +177,10 @@ public class PetitionController {
         @PathVariable("caseId")
         @ApiParam("Unique identifier of the session that was submitted to CCD") String caseId
     ) {
-        CaseDetails retrievedCase = petitionService.retrievePetitionByCaseId(jwt, caseId);
+        CaseDetails retrievedCase = Optional.ofNullable(
+            petitionService.retrievePetitionByCaseId(jwt, caseId)
+        ).orElse(CaseDetails.builder().build());
 
-        return retrievedCase == null ? ResponseEntity.notFound().build() : ResponseEntity.ok(retrievedCase);
+        return retrievedCase.getId() == null ? ResponseEntity.notFound().build() : ResponseEntity.ok(retrievedCase);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/CcdRetrievalService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/CcdRetrievalService.java
@@ -13,4 +13,6 @@ public interface CcdRetrievalService {
         throws DuplicateCaseException;
 
     CaseDetails retrieveCase(String authorisation) throws DuplicateCaseException;
+
+    CaseDetails retrieveCaseById(String authorisation, String caseId);
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/PetitionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/PetitionService.java
@@ -15,6 +15,8 @@ public interface PetitionService {
 
     CaseDetails retrievePetition(String authorisation) throws DuplicateCaseException;
 
+    CaseDetails retrievePetitionByCaseId(String authorisation, String caseId);
+
     void saveDraft(String authorisation, Map<String, Object> data, boolean divorceFormat);
 
     void createDraft(String authorisation, Map<String, Object> data, boolean divorceFormat);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdRetrievalServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdRetrievalServiceImpl.java
@@ -86,6 +86,20 @@ public class CcdRetrievalServiceImpl extends BaseCcdCaseService implements CcdRe
         return caseDetailsList.get(0);
     }
 
+    @Override
+    public CaseDetails retrieveCaseById(String authorisation, String caseId) {
+        UserDetails userDetails = getUserDetails(authorisation);
+
+        return coreCaseDataApi.readForCitizen(
+            getBearerUserToken(authorisation),
+            getServiceAuthToken(),
+            userDetails.getId(),
+            jurisdictionId,
+            caseType,
+            caseId
+        );
+    }
+
     private List<CaseDetails> getCaseListForUser(String authorisation, String userId) {
 
         return coreCaseDataApi.searchForCitizen(

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/PetitionServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/PetitionServiceImpl.java
@@ -59,6 +59,11 @@ public class PetitionServiceImpl implements PetitionService, ApplicationListener
     }
 
     @Override
+    public CaseDetails retrievePetitionByCaseId(String authorisation, String caseId) {
+        return ccdRetrievalService.retrieveCaseById(authorisation, caseId);
+    }
+
+    @Override
     public void saveDraft(String authorisation, Map<String, Object> data, boolean divorceFormat) {
         draftService.saveDraft(authorisation, data, divorceFormat);
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/PetitionControllerUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/PetitionControllerUTest.java
@@ -179,7 +179,7 @@ public class PetitionControllerUTest {
 
     @Test
     public void givenCaseFound_whenRetrieveCaseById_thenReturnCase() throws DuplicateCaseException {
-        final CaseDetails caseDetails = CaseDetails.builder().build();
+        final CaseDetails caseDetails = CaseDetails.builder().id(123456789L).build();
 
         when(petitionService.retrievePetitionByCaseId(AUTHORISATION, TEST_CASE_ID)).thenReturn(caseDetails);
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/PetitionControllerUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/PetitionControllerUTest.java
@@ -27,6 +27,7 @@ import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.Ca
 @RunWith(MockitoJUnitRunner.class)
 public class PetitionControllerUTest {
     private static final String AUTHORISATION = "user";
+    private static final String TEST_CASE_ID = "test.id";
 
     @Mock
     private PetitionService petitionService;
@@ -174,6 +175,31 @@ public class PetitionControllerUTest {
         assertEquals(caseDetails, actual.getBody());
 
         verify(petitionService).retrievePetition(AUTHORISATION);
+    }
+
+    @Test
+    public void givenCaseFound_whenRetrieveCaseById_thenReturnCase() throws DuplicateCaseException {
+        final CaseDetails caseDetails = CaseDetails.builder().build();
+
+        when(petitionService.retrievePetitionByCaseId(AUTHORISATION, TEST_CASE_ID)).thenReturn(caseDetails);
+
+        ResponseEntity<CaseDetails> actual = classUnderTest.retrieveCaseById(AUTHORISATION, TEST_CASE_ID);
+
+        assertEquals(HttpStatus.OK, actual.getStatusCode());
+        assertEquals(caseDetails, actual.getBody());
+
+        verify(petitionService).retrievePetitionByCaseId(AUTHORISATION, TEST_CASE_ID);
+    }
+
+    @Test
+    public void givenCaseNotFound_whenRetrieveCaseById_thenNotFound() throws DuplicateCaseException {
+        when(petitionService.retrievePetitionByCaseId(AUTHORISATION, TEST_CASE_ID)).thenReturn(null);
+
+        ResponseEntity<CaseDetails> actual = classUnderTest.retrieveCaseById(AUTHORISATION, TEST_CASE_ID);
+
+        assertEquals(HttpStatus.NOT_FOUND, actual.getStatusCode());
+
+        verify(petitionService).retrievePetitionByCaseId(AUTHORISATION, TEST_CASE_ID);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrievePetitionByCaseIdITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrievePetitionByCaseIdITest.java
@@ -57,7 +57,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class RetrievePetitionByCaseIdITest extends AuthIdamMockSupport {
-    private static final String API_URL = "/casemaintenance/version/1/retrieveCaseById";
+    private static final String API_URL = "/casemaintenance/version/1/case";
 
     @Value("${ccd.jurisdictionid}")
     private String jurisdictionId;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrievePetitionByCaseIdITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrievePetitionByCaseIdITest.java
@@ -53,7 +53,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @TestPropertySource(properties = {
     "feign.hystrix.enabled=false",
     "eureka.client.enabled=false"
-})
+    })
 @AutoConfigureMockMvc
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class RetrievePetitionByCaseIdITest extends AuthIdamMockSupport {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrievePetitionByCaseIdITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrievePetitionByCaseIdITest.java
@@ -1,0 +1,124 @@
+package uk.gov.hmcts.reform.divorce.casemaintenanceservice.functionaltest;
+
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import com.github.tomakehurst.wiremock.matching.EqualToPattern;
+import com.github.tomakehurst.wiremock.matching.StringValuePattern;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.web.client.HttpClientErrorException;
+import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.divorce.casemaintenanceservice.CaseMaintenanceServiceApplication;
+import uk.gov.hmcts.reform.divorce.casemaintenanceservice.client.DraftStoreClient;
+import uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CaseState;
+import uk.gov.hmcts.reform.divorce.casemaintenanceservice.draftstore.domain.model.CitizenCaseState;
+import uk.gov.hmcts.reform.divorce.casemaintenanceservice.draftstore.model.Draft;
+import uk.gov.hmcts.reform.divorce.casemaintenanceservice.draftstore.model.DraftList;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = CaseMaintenanceServiceApplication.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@PropertySource(value = "classpath:application.yml")
+@TestPropertySource(properties = {
+    "feign.hystrix.enabled=false",
+    "eureka.client.enabled=false"
+})
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+public class RetrievePetitionByCaseIdITest extends AuthIdamMockSupport {
+    private static final String API_URL = "/casemaintenance/version/1/retrieveCaseById";
+
+    @Value("${ccd.jurisdictionid}")
+    private String jurisdictionId;
+
+    @Value("${ccd.casetype}")
+    private String caseType;
+
+    @MockBean
+    private CoreCaseDataApi coreCaseDataApi;
+
+    @Autowired
+    private MockMvc webClient;
+
+    @Test
+    public void givenCaseExistsWithId_whenRetrievePetitionById_thenReturnCaseDetails()
+        throws Exception {
+        final String message = getUserDetails();
+        final String serviceToken = "serviceToken";
+        stubUserDetailsEndpoint(HttpStatus.OK, new EqualToPattern(USER_TOKEN), message);
+
+        final Long caseId = 1L;
+        final String testCaseId = String.valueOf(caseId);
+
+        final CaseDetails caseDetails = createCaseDetails(caseId, "state");
+
+        when(serviceTokenGenerator.generate()).thenReturn(serviceToken);
+        when(coreCaseDataApi
+            .readForCitizen(USER_TOKEN, serviceToken, USER_ID, jurisdictionId, caseType, testCaseId))
+            .thenReturn(caseDetails);
+
+        webClient.perform(MockMvcRequestBuilders.get(API_URL + "/" + testCaseId)
+            .header(HttpHeaders.AUTHORIZATION, USER_TOKEN)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content()
+                .json(ObjectMapperTestUtil
+                    .convertObjectToJsonString(caseDetails)));
+    }
+
+    @Test
+    public void givenCaseDoesNotExistWithId_whenRetrievePetitionById_thenReturnCaseDetails()
+        throws Exception {
+        final String message = getUserDetails();
+        final String serviceToken = "serviceToken";
+        stubUserDetailsEndpoint(HttpStatus.OK, new EqualToPattern(USER_TOKEN), message);
+
+        final Long caseId = 1L;
+        final String testCaseId = String.valueOf(caseId);
+
+        when(serviceTokenGenerator.generate()).thenReturn(serviceToken);
+        when(coreCaseDataApi
+            .readForCitizen(USER_TOKEN, serviceToken, USER_ID, jurisdictionId, caseType, testCaseId))
+            .thenReturn(null);
+
+        webClient.perform(MockMvcRequestBuilders.get(API_URL + "/" + testCaseId)
+            .header(HttpHeaders.AUTHORIZATION, USER_TOKEN)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
+    }
+
+    private CaseDetails createCaseDetails(Long id, String state) {
+        return CaseDetails.builder().id(id).state(state).build();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdRetrievalServiceImplUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdRetrievalServiceImplUTest.java
@@ -369,6 +369,28 @@ public class CcdRetrievalServiceImplUTest {
                 Collections.emptyMap());
     }
 
+    @Test
+    public void givenCaseId_whenRetrieveCaseById_thenReturnTheCase() throws Exception {
+        String testCaseId = String.valueOf(CASE_ID_1);
+        CaseDetails caseDetails = CaseDetails.builder().build();
+
+        final UserDetails userDetails = UserDetails.builder().id(USER_ID).build();
+
+        when(userService.retrieveUserDetails(BEARER_AUTHORISATION)).thenReturn(userDetails);
+        when(authTokenGenerator.generate()).thenReturn(SERVICE_TOKEN);
+        when(coreCaseDataApi
+            .readForCitizen(BEARER_AUTHORISATION, SERVICE_TOKEN, USER_ID, JURISDICTION_ID, CASE_TYPE,
+                testCaseId)).thenReturn(caseDetails);
+
+        assertEquals(caseDetails, classUnderTest.retrieveCaseById(AUTHORISATION, testCaseId));
+
+        verify(userService).retrieveUserDetails(BEARER_AUTHORISATION);
+        verify(authTokenGenerator).generate();
+        verify(coreCaseDataApi)
+            .readForCitizen(BEARER_AUTHORISATION, SERVICE_TOKEN, USER_ID, JURISDICTION_ID, CASE_TYPE,
+                testCaseId);
+    }
+
     private CaseDetails createCaseDetails(Long id, String state) {
         return CaseDetails.builder().id(id).state(state).build();
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/PetitionServiceImplUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/PetitionServiceImplUTest.java
@@ -28,6 +28,7 @@ import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.Ca
 public class PetitionServiceImplUTest {
     private static final String AUTHORISATION = "userToken";
     private static final boolean DIVORCE_FORMAT = false;
+    private static final String TEST_CASE_ID = "test.id";
 
     @Mock
     private CcdRetrievalService ccdRetrievalService;
@@ -143,6 +144,17 @@ public class PetitionServiceImplUTest {
         assertEquals(caseDetails, classUnderTest.retrievePetition(AUTHORISATION));
 
         verify(ccdRetrievalService).retrieveCase(AUTHORISATION);
+    }
+
+    @Test
+    public void whenRetrievePetitionById_thenProceedAsExpected() throws DuplicateCaseException {
+        final CaseDetails caseDetails = CaseDetails.builder().build();
+
+        when(ccdRetrievalService.retrieveCaseById(AUTHORISATION, TEST_CASE_ID)).thenReturn(caseDetails);
+
+        assertEquals(caseDetails, classUnderTest.retrievePetitionByCaseId(AUTHORISATION, TEST_CASE_ID));
+
+        verify(ccdRetrievalService).retrieveCaseById(AUTHORISATION, TEST_CASE_ID);
     }
 
     @Test


### PR DESCRIPTION
Exposes another CCD citizen endpoint for use, to retrieve case details based on the case id passed in.

This is needed for the population of existing case data functionality needed for updates.