### PR TITLE
DIV-3830: Replaced invalid emails with proper gov-notify one

### DIFF
--- a/src/integrationTest/resources/ccd-submission-payload/addresses-no-hwf.json
+++ b/src/integrationTest/resources/ccd-submission-payload/addresses-no-hwf.json
@@ -8,7 +8,7 @@
     "D8MarriageIsSameSexCouple":"NO",
     "D8MarriageDate":"2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert":"YES",
-    "D8PetitionerEmail":"email@email.com",
+    "D8PetitionerEmail":"simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",

--- a/src/integrationTest/resources/ccd-submission-payload/addresses.json
+++ b/src/integrationTest/resources/ccd-submission-payload/addresses.json
@@ -8,7 +8,7 @@
     "D8MarriageIsSameSexCouple":"NO",
     "D8MarriageDate":"2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert":"YES",
-    "D8PetitionerEmail":"email@email.com",
+    "D8PetitionerEmail":"simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",

--- a/src/integrationTest/resources/ccd-submission-payload/d8-document.json
+++ b/src/integrationTest/resources/ccd-submission-payload/d8-document.json
@@ -9,7 +9,7 @@
     "D8MarriageDate":"2001-02-02",
     "D8MarriedInUk":"YES",
     "D8PetitionerNameDifferentToMarriageCert":"YES",
-    "D8PetitionerEmail":"email@email.com",
+    "D8PetitionerEmail":"simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",

--- a/src/integrationTest/resources/ccd-submission-payload/how-name-changed.json
+++ b/src/integrationTest/resources/ccd-submission-payload/how-name-changed.json
@@ -8,7 +8,7 @@
     "D8MarriageIsSameSexCouple":"NO",
     "D8MarriageDate":"2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert":"YES",
-    "D8PetitionerEmail":"email@email.com",
+    "D8PetitionerEmail":"simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",

--- a/src/integrationTest/resources/ccd-submission-payload/jurisdiction-6-12.json
+++ b/src/integrationTest/resources/ccd-submission-payload/jurisdiction-6-12.json
@@ -8,7 +8,7 @@
     "D8MarriageIsSameSexCouple":"NO",
     "D8MarriageDate":"2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert":"YES",
-    "D8PetitionerEmail":"email@email.com",
+    "D8PetitionerEmail":"simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",

--- a/src/integrationTest/resources/ccd-submission-payload/jurisdiction-all.json
+++ b/src/integrationTest/resources/ccd-submission-payload/jurisdiction-all.json
@@ -8,7 +8,7 @@
     "D8MarriageIsSameSexCouple":"YES",
     "D8MarriageDate":"2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert":"YES",
-    "D8PetitionerEmail":"email@email.com",
+    "D8PetitionerEmail":"simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",

--- a/src/integrationTest/resources/ccd-submission-payload/linked-case.json
+++ b/src/integrationTest/resources/ccd-submission-payload/linked-case.json
@@ -8,7 +8,7 @@
     "D8MarriageIsSameSexCouple":"NO",
     "D8MarriageDate":"2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert":"YES",
-    "D8PetitionerEmail":"email@email.com",
+    "D8PetitionerEmail":"simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",

--- a/src/integrationTest/resources/ccd-submission-payload/reason-adultery.json
+++ b/src/integrationTest/resources/ccd-submission-payload/reason-adultery.json
@@ -8,7 +8,7 @@
     "D8MarriageIsSameSexCouple":"NO",
     "D8MarriageDate":"2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert":"YES",
-    "D8PetitionerEmail":"email@email.com",
+    "D8PetitionerEmail":"simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",

--- a/src/integrationTest/resources/ccd-submission-payload/reason-desertion.json
+++ b/src/integrationTest/resources/ccd-submission-payload/reason-desertion.json
@@ -8,7 +8,7 @@
     "D8MarriageIsSameSexCouple":"NO",
     "D8MarriageDate":"2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert":"YES",
-    "D8PetitionerEmail":"email@email.com",
+    "D8PetitionerEmail":"simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",

--- a/src/integrationTest/resources/ccd-submission-payload/reason-separation.json
+++ b/src/integrationTest/resources/ccd-submission-payload/reason-separation.json
@@ -8,7 +8,7 @@
     "D8MarriageIsSameSexCouple":"NO",
     "D8MarriageDate":"2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert":"YES",
-    "D8PetitionerEmail":"email@email.com",
+    "D8PetitionerEmail":"simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",

--- a/src/integrationTest/resources/ccd-submission-payload/reason-unreasonable-behaviour.json
+++ b/src/integrationTest/resources/ccd-submission-payload/reason-unreasonable-behaviour.json
@@ -8,7 +8,7 @@
     "D8MarriageIsSameSexCouple":"NO",
     "D8MarriageDate":"2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert":"YES",
-    "D8PetitionerEmail":"email@email.com",
+    "D8PetitionerEmail":"simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",

--- a/src/integrationTest/resources/ccd-submission-payload/same-sex.json
+++ b/src/integrationTest/resources/ccd-submission-payload/same-sex.json
@@ -8,7 +8,7 @@
     "D8MarriageIsSameSexCouple":"YES",
     "D8MarriageDate":"2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert":"YES",
-    "D8PetitionerEmail":"email@email.com",
+    "D8PetitionerEmail":"simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",

--- a/src/integrationTest/resources/ccd-update-payload/update-addresses.json
+++ b/src/integrationTest/resources/ccd-update-payload/update-addresses.json
@@ -8,7 +8,7 @@
     "D8MarriageIsSameSexCouple":"NO",
     "D8MarriageDate":"2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert":"YES",
-    "D8PetitionerEmail":"email@email.com",
+    "D8PetitionerEmail":"simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",

--- a/src/test/resources/ccd-submission-payload/addresses-no-hwf.json
+++ b/src/test/resources/ccd-submission-payload/addresses-no-hwf.json
@@ -8,7 +8,7 @@
     "D8MarriageIsSameSexCouple":"NO",
     "D8MarriageDate":"2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert":"YES",
-    "D8PetitionerEmail":"email@email.com",
+    "D8PetitionerEmail":"simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",

--- a/src/test/resources/ccd-submission-payload/addresses.json
+++ b/src/test/resources/ccd-submission-payload/addresses.json
@@ -8,7 +8,7 @@
     "D8MarriageIsSameSexCouple":"NO",
     "D8MarriageDate":"2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert":"YES",
-    "D8PetitionerEmail":"email@email.com",
+    "D8PetitionerEmail":"simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DIV-3830
Replaced instances of email@email.com with proper gov notify simulate-delivered email in integration tests