### PR TITLE
Remove unused imports and fix Wiremock Content Cleanup on Functional Unit tests

### DIFF
--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/AuthIdamMockSupport.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/AuthIdamMockSupport.java
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.AuthenticateUserResponse;
@@ -32,7 +31,6 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
 
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class AuthIdamMockSupport {
     private static final String IDAM_USER_DETAILS_CONTEXT_PATH = "/details";
     private static final String IDAM_USER_AUTHENTICATE_CONTEXT_PATH = "/oauth2/authorize";

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/AuthIdamMockSupport.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/AuthIdamMockSupport.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.AuthenticateUserResponse;
@@ -31,6 +32,7 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
 
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class AuthIdamMockSupport {
     private static final String IDAM_USER_DETAILS_CONTEXT_PATH = "/details";
     private static final String IDAM_USER_AUTHENTICATE_CONTEXT_PATH = "/oauth2/authorize";

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/CcdSubmissionITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/CcdSubmissionITest.java
@@ -52,7 +52,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     "draft.delete.async=false"
     })
 @AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class CcdSubmissionITest extends AuthIdamMockSupport {
     private static final String API_URL = "/casemaintenance/version/1/submit";
     private static final String VALID_PAYLOAD_PATH = "ccd-submission-payload/addresses.json";

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/CcdUpdateITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/CcdUpdateITest.java
@@ -45,7 +45,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     "eureka.client.enabled=false"
     })
 @AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class CcdUpdateITest extends AuthIdamMockSupport {
     private static final String API_URL = "/casemaintenance/version/1/updateCase";
     private static final String EVENT_ID = "payment";

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/CreateDraftServiceITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/CreateDraftServiceITest.java
@@ -46,7 +46,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     "eureka.client.enabled=false"
     })
 @AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class CreateDraftServiceITest extends AuthIdamMockSupport {
     private static final String API_URL = "/casemaintenance/version/1/drafts";
     private static final String DRAFTS_CONTEXT_PATH = "/drafts";

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/DeleteDraftServiceITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/DeleteDraftServiceITest.java
@@ -36,7 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     "eureka.client.enabled=false"
     })
 @AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class DeleteDraftServiceITest extends AuthIdamMockSupport {
     private static final String API_URL = "/casemaintenance/version/1/drafts";
     private static final String DRAFTS_CONTEXT_PATH = "/drafts";

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/GetCaseITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/GetCaseITest.java
@@ -40,7 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     "eureka.client.enabled=false"
     })
 @AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class GetCaseITest extends AuthIdamMockSupport {
     private static final String API_URL = "/casemaintenance/version/1/case";
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/LinkRespondentITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/LinkRespondentITest.java
@@ -51,7 +51,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     "eureka.client.enabled=false"
     })
 @AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class LinkRespondentITest extends AuthIdamMockSupport {
     private static final String CASE_ID = "caseId";
     private static final String LETTER_HOLDER_ID = "letterHolderId";

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrieveAOSPostCompletedITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrieveAOSPostCompletedITest.java
@@ -41,7 +41,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     "eureka.client.enabled=false"
     })
 @AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class RetrieveAOSPostCompletedITest  extends AuthIdamMockSupport {
     private static final String API_URL = "/casemaintenance/version/1/retrieveAosCase";
     private static final String CHECK_CCD_PARAM = "checkCcd";

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrieveAllDraftsServiceITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrieveAllDraftsServiceITest.java
@@ -45,7 +45,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     "eureka.client.enabled=false"
     })
 @AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class RetrieveAllDraftsServiceITest extends AuthIdamMockSupport {
     private static final String API_URL = "/casemaintenance/version/1/drafts";
     private static final String DRAFTS_CONTEXT_PATH = "/drafts";

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrieveAosCaseITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrieveAosCaseITest.java
@@ -54,7 +54,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     "eureka.client.enabled=false"
     })
 @AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class RetrieveAosCaseITest extends AuthIdamMockSupport {
     private static final String API_URL = "/casemaintenance/version/1/retrieveAosCase";
     private static final String CHECK_CCD_PARAM = "checkCcd";

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrieveAosCaseITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrieveAosCaseITest.java
@@ -6,7 +6,6 @@ import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrievePetitionByCaseIdITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrievePetitionByCaseIdITest.java
@@ -1,9 +1,6 @@
 package uk.gov.hmcts.reform.divorce.casemaintenanceservice.functionaltest;
 
-import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
-import com.github.tomakehurst.wiremock.matching.StringValuePattern;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,28 +18,11 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.CaseMaintenanceServiceApplication;
-import uk.gov.hmcts.reform.divorce.casemaintenanceservice.client.DraftStoreClient;
-import uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CaseState;
-import uk.gov.hmcts.reform.divorce.casemaintenanceservice.draftstore.domain.model.CitizenCaseState;
-import uk.gov.hmcts.reform.divorce.casemaintenanceservice.draftstore.model.Draft;
-import uk.gov.hmcts.reform.divorce.casemaintenanceservice.draftstore.model.DraftList;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Map;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.mockito.Mockito.when;
-import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
-import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrievePetitionByCaseIdITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrievePetitionByCaseIdITest.java
@@ -35,7 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     "eureka.client.enabled=false"
     })
 @AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class RetrievePetitionByCaseIdITest extends AuthIdamMockSupport {
     private static final String API_URL = "/casemaintenance/version/1/case";
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrievePetitionITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrievePetitionITest.java
@@ -55,7 +55,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     "eureka.client.enabled=false"
     })
 @AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class RetrievePetitionITest extends AuthIdamMockSupport {
     private static final String API_URL = "/casemaintenance/version/1/retrieveCase";
     private static final String CHECK_CCD_PARAM = "checkCcd";

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/SaveDraftServiceITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/SaveDraftServiceITest.java
@@ -51,7 +51,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     "eureka.client.enabled=false"
     })
 @AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class SaveDraftServiceITest extends AuthIdamMockSupport {
     private static final String API_URL = "/casemaintenance/version/1/drafts";
     private static final String DRAFTS_CONTEXT_PATH = "/drafts";

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/UnlinkUserITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/UnlinkUserITest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -38,6 +39,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     "eureka.client.enabled=false"
     })
 @AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class UnlinkUserITest  extends AuthIdamMockSupport {
 
     private static final String CASE_ID = "caseId";


### PR DESCRIPTION
Functional Unit Test keeps failing because Wiremock is unable to spin up local IDAM mock on localhost:4503 properly intermittently. This PR is to try and see if we can fix the issue consistently.