### PR TITLE
Retrieve case by id regardless of role

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -50,5 +50,13 @@ withPipeline(type , product, component) {
         echo '${product}-${component} checked out'
     }
 
+    after('functionalTest:aat') {
+        steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
+    }
+
+    after('functionalTest:preview') {
+        steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
+    }
+
     enableSlackNotifications(channel)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,8 @@ def versions = [
     pitest: '1.4.2',
     gradlePitest: '1.3.0',
     sonarPitest: '0.5',
-    jacksonDatabind: '2.9.8'
+    jacksonDatabind: '2.9.8',
+    springCloudDependencies: '2.0.2.RELEASE'
 ]
 
 dependencies {
@@ -181,6 +182,7 @@ dependencies {
 
     compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     testCompile group: 'com.github.tomakehurst', name:'wiremock', version: versions.wiremockVersion
+    testCompile group: 'org.springframework.cloud', name: 'spring-cloud-contract-wiremock', version: versions.springCloudDependencies
     testCompile('org.springframework.boot:spring-boot-starter-test')
     runtime('org.springframework.boot:spring-boot-devtools')
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/ccd/CcdUpdateTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/ccd/CcdUpdateTest.java
@@ -32,6 +32,19 @@ public class CcdUpdateTest extends CcdUpdateSupport {
     }
 
     @Test
+    public void shouldReturnCaseIdWhenUpdatingDataAfterInitialSubmitWithCaseWorker() throws Exception {
+        String userToken = getUserToken();
+        String caseWorkerToken = getCaseWorkerToken();
+
+        Long caseId = getCaseIdFromSubmittingANewCase(userToken);
+
+        Response cmsResponse = updateCase("update-addresses.json", caseId, EVENT_ID, caseWorkerToken);
+
+        assertEquals(HttpStatus.OK.value(), cmsResponse.getStatusCode());
+        assertEquals(caseId, cmsResponse.getBody().path("id"));
+    }
+
+    @Test
     public void shouldReturnCaseIdWhenUpdatingPaymentAfterUpdatingWithPaymentReference() throws Exception {
         String userToken = getUserToken();
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/ccd/CcdUpdateTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/ccd/CcdUpdateTest.java
@@ -34,7 +34,7 @@ public class CcdUpdateTest extends CcdUpdateSupport {
     @Test
     public void shouldReturnCaseIdWhenUpdatingDataAfterInitialSubmitWithCaseWorker() throws Exception {
         String userToken = getUserToken();
-        String caseWorkerToken = getCaseWorkerToken();
+        String caseWorkerToken = getPureCaseWorkerToken();
 
         Long caseId = getCaseIdFromSubmittingANewCase(userToken);
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
@@ -35,7 +35,11 @@ public abstract class IntegrationTest {
     }
 
     protected UserDetails getCaseWorkerUser() {
-        return idamTestSupport.createAnonymousCaseWorkerUser();
+        return idamTestSupport.createAnonymousCaseWorkerUser(true);
+    }
+
+    protected String getPureCaseWorkerToken() {
+        return idamTestSupport.createAnonymousCaseWorkerUser(false).getAuthToken();
     }
 
     protected String getCaseWorkerToken() {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
@@ -37,4 +37,8 @@ public abstract class IntegrationTest {
     protected UserDetails getCaseWorkerUser() {
         return idamTestSupport.createAnonymousCaseWorkerUser();
     }
+
+    protected String getCaseWorkerToken() {
+        return getCaseWorkerUser().getAuthToken();
+    }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
@@ -35,14 +35,10 @@ public abstract class IntegrationTest {
     }
 
     protected UserDetails getCaseWorkerUser() {
-        return idamTestSupport.createAnonymousCaseWorkerUser(true);
+        return idamTestSupport.createAnonymousCaseWorkerUser();
     }
 
     protected String getPureCaseWorkerToken() {
-        return idamTestSupport.createAnonymousCaseWorkerUser(false).getAuthToken();
-    }
-
-    protected String getCaseWorkerToken() {
-        return getCaseWorkerUser().getAuthToken();
+        return idamTestSupport.createPureCaseWorkerUser().getAuthToken();
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/petition/CcdRetrieveCaseByIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/petition/CcdRetrieveCaseByIdTest.java
@@ -3,13 +3,7 @@ package uk.gov.hmcts.reform.divorce.petition;
 import io.restassured.response.Response;
 import org.junit.Test;
 import org.springframework.http.HttpStatus;
-import uk.gov.hmcts.reform.divorce.model.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.PetitionSupport;
-import uk.gov.hmcts.reform.divorce.util.ResourceLoader;
-
-import java.util.Collections;
-import java.util.Map;
-
 import static org.junit.Assert.assertEquals;
 
 public class CcdRetrieveCaseByIdTest extends PetitionSupport {
@@ -21,6 +15,19 @@ public class CcdRetrieveCaseByIdTest extends PetitionSupport {
         Long caseId = getCaseIdFromSubmittingANewCase(userToken);
 
         Response cmsResponse = retrieveCaseById(userToken, String.valueOf(caseId));
+
+        assertEquals(HttpStatus.OK.value(), cmsResponse.getStatusCode());
+        assertEquals(caseId, cmsResponse.path("id"));
+    }
+
+    @Test
+    public void givenOneSubmittedCaseInCcd_whenRetrieveCaseByCaseWorker_thenReturnTheCase() throws Exception {
+        final String userToken = getUserToken();
+        final String caseWorkerToken = getCaseWorkerToken();
+
+        Long caseId = getCaseIdFromSubmittingANewCase(userToken);
+
+        Response cmsResponse = retrieveCaseById(caseWorkerToken, String.valueOf(caseId));
 
         assertEquals(HttpStatus.OK.value(), cmsResponse.getStatusCode());
         assertEquals(caseId, cmsResponse.path("id"));

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/petition/CcdRetrieveCaseByIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/petition/CcdRetrieveCaseByIdTest.java
@@ -4,6 +4,7 @@ import io.restassured.response.Response;
 import org.junit.Test;
 import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.divorce.support.PetitionSupport;
+
 import static org.junit.Assert.assertEquals;
 
 public class CcdRetrieveCaseByIdTest extends PetitionSupport {
@@ -23,7 +24,7 @@ public class CcdRetrieveCaseByIdTest extends PetitionSupport {
     @Test
     public void givenOneSubmittedCaseInCcd_whenRetrieveCaseByCaseWorker_thenReturnTheCase() throws Exception {
         final String userToken = getUserToken();
-        final String caseWorkerToken = getCaseWorkerToken();
+        final String caseWorkerToken = getPureCaseWorkerToken();
 
         Long caseId = getCaseIdFromSubmittingANewCase(userToken);
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/IdamTestSupport.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/IdamTestSupport.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.divorce.support;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import uk.gov.hmcts.reform.divorce.idam.utils.IdamUtils;
 import uk.gov.hmcts.reform.divorce.model.PinResponse;
 import uk.gov.hmcts.reform.divorce.model.RegisterUserRequest;
@@ -21,6 +22,9 @@ public class IdamTestSupport {
     private static final String CITIZEN_ROLE = "citizen";
 
     private UserDetails defaultCaseWorkerUser;
+
+    @Value("${idam.caseworker.password}")
+    private String caseWorkerPassword;
 
     @Autowired
     private IdamUtils idamUtils;
@@ -65,7 +69,7 @@ public class IdamTestSupport {
     public UserDetails createPureCaseWorkerUser() {
         synchronized (this) {
             final String username = "simulate-delivered" + UUID.randomUUID();
-            final String password = UUID.randomUUID().toString().toUpperCase(Locale.ENGLISH);
+            final String password = caseWorkerPassword;
 
             return createNewUser(username, password, CASEWORKER_ROLE);
         }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/IdamTestSupport.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/IdamTestSupport.java
@@ -7,12 +7,18 @@ import uk.gov.hmcts.reform.divorce.model.RegisterUserRequest;
 import uk.gov.hmcts.reform.divorce.model.UserDetails;
 import uk.gov.hmcts.reform.divorce.model.UserGroup;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
 
 public class IdamTestSupport {
     private static final String CASE_WORKER_USERNAME = "CASE_WORKER_USER_NAME";
     private static final String CASE_WORKER_PASSWORD = "CASE_WORKER_PASSWORD";
+    private static final String CASEWORKER_ROLE = "caseworker";
+    private static final String CASEWORKER_CITIZEN_ROLE = "caseworker-citizen";
+    private static final String CITIZEN_ROLE = "citizen";
 
     private UserDetails defaultCaseWorkerUser;
 
@@ -21,7 +27,7 @@ public class IdamTestSupport {
 
     public UserDetails createRespondentUser(String username, String pin) {
         final UserDetails respondentUser = createNewUser(username,
-            UUID.randomUUID().toString().toUpperCase(Locale.ENGLISH), false);
+            UUID.randomUUID().toString().toUpperCase(Locale.ENGLISH), CITIZEN_ROLE);
 
         final String pinAuthToken = idamUtils.authenticatePinUser(pin);
 
@@ -38,14 +44,18 @@ public class IdamTestSupport {
     }
 
     public PinResponse createPinUser(String firstName) {
-        final UserDetails caseWorkerUser = createAnonymousCaseWorkerUser();
+        final UserDetails caseWorkerUser = createAnonymousCaseWorkerUser(true);
         return idamUtils.generatePin(firstName, "",  caseWorkerUser.getAuthToken());
     }
 
-    public UserDetails createAnonymousCaseWorkerUser() {
+    public UserDetails createAnonymousCaseWorkerUser(Boolean hasCitizenRole) {
         synchronized (this) {
             if (defaultCaseWorkerUser == null) {
-                defaultCaseWorkerUser = createNewUser(CASE_WORKER_USERNAME, CASE_WORKER_PASSWORD, true);
+                defaultCaseWorkerUser = createNewUser(
+                    CASE_WORKER_USERNAME,
+                    CASE_WORKER_PASSWORD,
+                    hasCitizenRole ? CASEWORKER_CITIZEN_ROLE : CASEWORKER_ROLE
+                );
             }
 
             return defaultCaseWorkerUser;
@@ -57,15 +67,17 @@ public class IdamTestSupport {
             final String username = "simulate-delivered" + UUID.randomUUID();
             final String password = UUID.randomUUID().toString().toUpperCase(Locale.ENGLISH);
 
-            return createNewUser(username, password, false);
+            return createNewUser(username, password, CITIZEN_ROLE);
         }
     }
 
-    private UserDetails createNewUser(String username, String password, boolean caseworker) {
+    private UserDetails createNewUser(String username, String password, String roleType) {
         final String emailAddress =  username + "@notifications.service.gov.uk";
 
-        if (caseworker) {
-            createCaseWorkerCourtAdminUserInIdam(username, emailAddress, password);
+        if (CASEWORKER_CITIZEN_ROLE.equals(roleType)) {
+            createCaseWorkerCourtAdminUserInIdam(username, emailAddress, password, true);
+        } else if (CASEWORKER_ROLE.equals(roleType)) {
+            createCaseWorkerCourtAdminUserInIdam(username, emailAddress, password, false);
         } else {
             createCitizenUserInIdam(username, emailAddress, password);
         }
@@ -83,13 +95,22 @@ public class IdamTestSupport {
             .build();
     }
 
-    private void createCaseWorkerCourtAdminUserInIdam(String username, String emailAddress, String password) {
+    private void createCaseWorkerCourtAdminUserInIdam(String username, String emailAddress, String password,
+                                                      Boolean citizenRole) {
+        List<String> roles = new ArrayList<>(Arrays.asList(
+            "caseworker-divorce-courtadmin", "caseworker-divorce", "caseworker"
+        ));
+
+        if (citizenRole) {
+            roles.add("citizen");
+        }
+
         final RegisterUserRequest registerUserRequest =
             RegisterUserRequest.builder()
                 .email(emailAddress)
                 .forename(username)
                 .password(password)
-                .roles(new String[]{"caseworker-divorce", "caseworker-divorce-courtadmin", "caseworker"})
+                .roles(roles.toArray(new String[roles.size()]))
                 .userGroup(UserGroup.builder().code("caseworker").build())
                 .build();
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/IdamTestSupport.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/IdamTestSupport.java
@@ -44,21 +44,30 @@ public class IdamTestSupport {
     }
 
     public PinResponse createPinUser(String firstName) {
-        final UserDetails caseWorkerUser = createAnonymousCaseWorkerUser(true);
+        final UserDetails caseWorkerUser = createAnonymousCaseWorkerUser();
         return idamUtils.generatePin(firstName, "",  caseWorkerUser.getAuthToken());
     }
 
-    public UserDetails createAnonymousCaseWorkerUser(Boolean hasCitizenRole) {
+    public UserDetails createAnonymousCaseWorkerUser() {
         synchronized (this) {
             if (defaultCaseWorkerUser == null) {
                 defaultCaseWorkerUser = createNewUser(
                     CASE_WORKER_USERNAME,
                     CASE_WORKER_PASSWORD,
-                    hasCitizenRole ? CASEWORKER_CITIZEN_ROLE : CASEWORKER_ROLE
+                    CASEWORKER_CITIZEN_ROLE
                 );
             }
 
             return defaultCaseWorkerUser;
+        }
+    }
+
+    public UserDetails createPureCaseWorkerUser() {
+        synchronized (this) {
+            final String username = "simulate-delivered" + UUID.randomUUID();
+            final String password = UUID.randomUUID().toString().toUpperCase(Locale.ENGLISH);
+
+            return createNewUser(username, password, CASEWORKER_ROLE);
         }
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/IdamTestSupport.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/IdamTestSupport.java
@@ -89,7 +89,7 @@ public class IdamTestSupport {
                 .email(emailAddress)
                 .forename(username)
                 .password(password)
-                .roles(new String[]{"caseworker-divorce", "caseworker-divorce-courtadmin", "caseworker", "citizen"})
+                .roles(new String[]{"caseworker-divorce", "caseworker-divorce-courtadmin", "caseworker"})
                 .userGroup(UserGroup.builder().code("caseworker").build())
                 .build();
 

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -40,3 +40,7 @@ auth.idam.client.secret=dummysecret
 core_case_data.api.url=http://ccd-data-store-api-aat.service.core-compute-aat.internal
 
 idam.strategic.enabled=#{'${auth.idam.client.baseUrl}'.contains('.aat.')}
+
+idam.caseworker.password=dummypassword
+
+

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/UserDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/UserDetails.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.List;
+
 @Getter
 @Builder
 @Setter
@@ -15,4 +17,5 @@ public class UserDetails {
     private String forename;
     private String surname;
     private String authToken;
+    private List<String> roles;
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdRetrievalServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdRetrievalServiceImpl.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 public class CcdRetrievalServiceImpl extends BaseCcdCaseService implements CcdRetrievalService {
 
     private static final String CASEWORKER_ROLE = "caseworker";
+    private static final String CITIZEN_ROLE = "citizen";
 
     @Override
     public CaseDetails retrieveCase(String authorisation, Map<CaseStateGrouping, List<CaseState>> caseStateGrouping)
@@ -92,8 +93,9 @@ public class CcdRetrievalServiceImpl extends BaseCcdCaseService implements CcdRe
     @Override
     public CaseDetails retrieveCaseById(String authorisation, String caseId) {
         UserDetails userDetails = getUserDetails(authorisation);
+        List<String> userRoles = Optional.ofNullable(userDetails.getRoles()).orElse(Collections.emptyList());
 
-        if (Optional.ofNullable(userDetails.getRoles()).orElse(Collections.emptyList()).contains(CASEWORKER_ROLE)) {
+        if (userRoles.contains(CASEWORKER_ROLE) && !userRoles.contains(CITIZEN_ROLE)) {
             return coreCaseDataApi.readForCaseWorker(
                 getBearerUserToken(authorisation),
                 getServiceAuthToken(),

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdUpdateServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdUpdateServiceImpl.java
@@ -9,18 +9,21 @@ import uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.UserDetai
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.service.CcdUpdateService;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 @Service
 public class CcdUpdateServiceImpl extends BaseCcdCaseService implements CcdUpdateService {
 
     private static final String CASEWORKER_ROLE = "caseworker";
+    private static final String CITIZEN_ROLE = "citizen";
 
     @Override
     public CaseDetails update(String caseId, Object data, String eventId, String authorisation) {
         UserDetails userDetails = getUserDetails(authorisation);
+        List<String> userRoles = Optional.ofNullable(userDetails.getRoles()).orElse(Collections.emptyList());
 
-        if (Optional.ofNullable(userDetails.getRoles()).orElse(Collections.emptyList()).contains(CASEWORKER_ROLE)) {
+        if (userRoles.contains(CASEWORKER_ROLE) && !userRoles.contains(CITIZEN_ROLE)) {
             StartEventResponse startEventResponse = coreCaseDataApi.startEventForCaseWorker(
                 getBearerUserToken(authorisation),
                 getServiceAuthToken(),

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/AuthIdamMockSupport.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/AuthIdamMockSupport.java
@@ -9,6 +9,7 @@ import feign.FeignException;
 import org.junit.ClassRule;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.contract.wiremock.WireMockSpring;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -83,7 +84,7 @@ public class AuthIdamMockSupport {
     private String authClientSecret;
 
     @ClassRule
-    public static WireMockClassRule idamUserDetailsServer = new WireMockClassRule(4503);
+    public static WireMockClassRule idamUserDetailsServer = new WireMockClassRule(WireMockSpring.options().port(4503));
 
     @MockBean
     AuthTokenGenerator serviceTokenGenerator;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/AuthIdamMockSupport.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/AuthIdamMockSupport.java
@@ -21,6 +21,7 @@ import uk.gov.hmcts.reform.divorce.casemaintenanceservice.service.impl.UserServi
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -64,6 +65,8 @@ public class AuthIdamMockSupport {
     static final String BEARER_CASE_WORKER_TOKEN = BEARER + CASE_WORKER_TOKEN;
 
     private static final String CASE_WORKER_AUTH_CODE = "AuthCode";
+    private static final String CITIZEN_ROLE = "citizen";
+    private static final String CASEWORKER_ROLE = "caseworker";
 
     private final AuthenticateUserResponse authenticateUserResponse =
         getAuthenticateUserResponse();
@@ -126,15 +129,15 @@ public class AuthIdamMockSupport {
             getCaseWorkerUserDetails());
     }
 
-    private String getCaseWorkerUserDetails() {
-        return getUserDetails(CASE_WORKER_USER_ID, CASE_WORKER_TOKEN);
+    String getCaseWorkerUserDetails() {
+        return getUserDetails(CASE_WORKER_USER_ID, CASE_WORKER_TOKEN, CASEWORKER_ROLE);
     }
 
     String getUserDetails() {
-        return getUserDetails(USER_ID, USER_TOKEN);
+        return getUserDetails(USER_ID, USER_TOKEN, CITIZEN_ROLE);
     }
 
-    private String getUserDetails(String userId, String authToken) {
+    private String getUserDetails(String userId, String authToken, String role) {
         try {
             return new ObjectMapper().writeValueAsString(
                 UserDetails.builder()
@@ -143,6 +146,7 @@ public class AuthIdamMockSupport {
                     .email("test@test.com")
                     .forename("forename")
                     .surname("surname")
+                    .roles(Collections.singletonList(role))
                     .build());
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/CcdSubmissionITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/CcdSubmissionITest.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.contract.wiremock.WireMockSpring;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -68,7 +69,7 @@ public class CcdSubmissionITest extends AuthIdamMockSupport {
             "DIVORCE_CASE_SUBMISSION_EVENT_DESCRIPTION");
 
     @ClassRule
-    public static WireMockClassRule draftStoreServer = new WireMockClassRule(4601);
+    public static WireMockClassRule draftStoreServer = new WireMockClassRule(WireMockSpring.options().port(4601));
 
     @Value("${ccd.jurisdictionid}")
     private String jurisdictionId;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/CreateDraftServiceITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/CreateDraftServiceITest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.wiremock.WireMockSpring;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -62,7 +63,7 @@ public class CreateDraftServiceITest extends AuthIdamMockSupport {
     private MockMvc webClient;
 
     @ClassRule
-    public static WireMockClassRule draftStoreServer = new WireMockClassRule(4601);
+    public static WireMockClassRule draftStoreServer = new WireMockClassRule(WireMockSpring.options().port(4601));
 
     @Test
     public void givenJWTTokenIsNull_whenCreateDraft_thenReturnBadRequest() throws Exception {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/DeleteDraftServiceITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/DeleteDraftServiceITest.java
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.wiremock.WireMockSpring;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -45,7 +46,7 @@ public class DeleteDraftServiceITest extends AuthIdamMockSupport {
     private MockMvc webClient;
 
     @ClassRule
-    public static WireMockClassRule draftStoreServer = new WireMockClassRule(4601);
+    public static WireMockClassRule draftStoreServer = new WireMockClassRule(WireMockSpring.options().port(4601));
 
     @Test
     public void givenJWTTokenIsNull_whenDeleteDraft_thenReturnBadRequest() throws Exception {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrieveAllDraftsServiceITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrieveAllDraftsServiceITest.java
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.wiremock.WireMockSpring;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -57,7 +58,7 @@ public class RetrieveAllDraftsServiceITest extends AuthIdamMockSupport {
     private MockMvc webClient;
 
     @ClassRule
-    public static WireMockClassRule draftStoreServer = new WireMockClassRule(4601);
+    public static WireMockClassRule draftStoreServer = new WireMockClassRule(WireMockSpring.options().port(4601));
 
     @Test
     public void givenJWTTokenIsNull_whenRetrieveAllDrafts_thenReturnBadRequest() throws Exception {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrieveAosCaseITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrieveAosCaseITest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.contract.wiremock.WireMockSpring;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -64,10 +65,10 @@ public class RetrieveAosCaseITest extends AuthIdamMockSupport {
     private static final String DRAFT_DOCUMENT_TYPE_DIVORCE_FORMAT = "divorcedraft";
 
     @ClassRule
-    public static WireMockClassRule draftStoreServer = new WireMockClassRule(4601);
+    public static WireMockClassRule draftStoreServer = new WireMockClassRule(WireMockSpring.options().port(4601));
 
     @ClassRule
-    public static WireMockClassRule caseFormatterServer = new WireMockClassRule(4011);
+    public static WireMockClassRule caseFormatterServer = new WireMockClassRule(WireMockSpring.options().port(4011));
 
     @Value("${ccd.jurisdictionid}")
     private String jurisdictionId;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrievePetitionByCaseIdITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrievePetitionByCaseIdITest.java
@@ -79,7 +79,34 @@ public class RetrievePetitionByCaseIdITest extends AuthIdamMockSupport {
     }
 
     @Test
-    public void givenCaseDoesNotExistWithId_whenRetrievePetitionById_thenReturnCaseDetails()
+    public void givenCaseExistsWithId_whenRetrievePetitionByIdWithCaseworker_thenReturnCaseDetails()
+        throws Exception {
+        final String message = getCaseWorkerUserDetails();
+        final String serviceToken = "serviceToken";
+        stubUserDetailsEndpoint(HttpStatus.OK, new EqualToPattern(BEARER_CASE_WORKER_TOKEN), message);
+
+        final Long caseId = 1L;
+        final String testCaseId = String.valueOf(caseId);
+
+        final CaseDetails caseDetails = createCaseDetails(caseId, "state");
+
+        when(serviceTokenGenerator.generate()).thenReturn(serviceToken);
+        when(coreCaseDataApi
+            .readForCaseWorker(BEARER_CASE_WORKER_TOKEN, serviceToken, CASE_WORKER_USER_ID,
+                jurisdictionId, caseType, testCaseId))
+            .thenReturn(caseDetails);
+
+        webClient.perform(MockMvcRequestBuilders.get(API_URL + "/" + testCaseId)
+            .header(HttpHeaders.AUTHORIZATION, BEARER_CASE_WORKER_TOKEN)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content()
+                .json(ObjectMapperTestUtil
+                    .convertObjectToJsonString(caseDetails)));
+    }
+
+    @Test
+    public void givenCaseDoesNotExistWithId_whenRetrievePetitionById_thenReturnNotFound()
         throws Exception {
         final String message = getUserDetails();
         final String serviceToken = "serviceToken";

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrievePetitionITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrievePetitionITest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.contract.wiremock.WireMockSpring;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -68,10 +69,10 @@ public class RetrievePetitionITest extends AuthIdamMockSupport {
     private static final String SUBMITTED_PAYMENT_STATE = CitizenCaseState.SUBMITTED.getValue();
 
     @ClassRule
-    public static WireMockClassRule draftStoreServer = new WireMockClassRule(4601);
+    public static WireMockClassRule draftStoreServer = new WireMockClassRule(WireMockSpring.options().port(4601));
 
     @ClassRule
-    public static WireMockClassRule caseFormatterServer = new WireMockClassRule(4011);
+    public static WireMockClassRule caseFormatterServer = new WireMockClassRule(WireMockSpring.options().port(4011));
 
     @Value("${ccd.jurisdictionid}")
     private String jurisdictionId;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/SaveDraftServiceITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/SaveDraftServiceITest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.wiremock.WireMockSpring;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -69,7 +70,7 @@ public class SaveDraftServiceITest extends AuthIdamMockSupport {
     private MockMvc webClient;
 
     @ClassRule
-    public static WireMockClassRule draftStoreServer = new WireMockClassRule(4601);
+    public static WireMockClassRule draftStoreServer = new WireMockClassRule(WireMockSpring.options().port(4601));
 
     @Test
     public void givenJWTTokenIsNull_whenSaveDraft_thenReturnBadRequest() throws Exception {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdRetrievalServiceImplUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdRetrievalServiceImplUTest.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.divorce.casemaintenanceservice.draftstore.domain.mode
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception.DuplicateCaseException;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.service.UserService;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -39,6 +40,7 @@ public class CcdRetrievalServiceImplUTest {
     private static final UserDetails USER_DETAILS = UserDetails.builder().id(USER_ID).build();
     private static final Long CASE_ID_1 = 1L;
     private static final String CASEWORKER_ROLE = "caseworker";
+    private static final String CITIZEN_ROLE = "citizen";
 
     @Mock
     private CoreCaseDataApi coreCaseDataApi;
@@ -412,6 +414,30 @@ public class CcdRetrievalServiceImplUTest {
         verify(authTokenGenerator).generate();
         verify(coreCaseDataApi)
             .readForCaseWorker(BEARER_AUTHORISATION, SERVICE_TOKEN, USER_ID, JURISDICTION_ID, CASE_TYPE,
+                testCaseId);
+    }
+
+    @Test
+    public void givenCaseId_whenRetrieveCaseByIdWithCaseworkerCitizen_thenReturnTheCase() throws Exception {
+        String testCaseId = String.valueOf(CASE_ID_1);
+        CaseDetails caseDetails = CaseDetails.builder().build();
+        List<String> userRoles = Arrays.asList(CASEWORKER_ROLE, CITIZEN_ROLE);
+
+        final UserDetails userDetails = UserDetails.builder()
+            .id(USER_ID).roles(userRoles).build();
+
+        when(userService.retrieveUserDetails(BEARER_AUTHORISATION)).thenReturn(userDetails);
+        when(authTokenGenerator.generate()).thenReturn(SERVICE_TOKEN);
+        when(coreCaseDataApi
+            .readForCitizen(BEARER_AUTHORISATION, SERVICE_TOKEN, USER_ID, JURISDICTION_ID, CASE_TYPE,
+                testCaseId)).thenReturn(caseDetails);
+
+        assertEquals(caseDetails, classUnderTest.retrieveCaseById(AUTHORISATION, testCaseId));
+
+        verify(userService).retrieveUserDetails(BEARER_AUTHORISATION);
+        verify(authTokenGenerator).generate();
+        verify(coreCaseDataApi)
+            .readForCitizen(BEARER_AUTHORISATION, SERVICE_TOKEN, USER_ID, JURISDICTION_ID, CASE_TYPE,
                 testCaseId);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdRetrievalServiceImplUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdRetrievalServiceImplUTest.java
@@ -38,6 +38,7 @@ public class CcdRetrievalServiceImplUTest {
     private static final String USER_ID = "someUserId";
     private static final UserDetails USER_DETAILS = UserDetails.builder().id(USER_ID).build();
     private static final Long CASE_ID_1 = 1L;
+    private static final String CASEWORKER_ROLE = "caseworker";
 
     @Mock
     private CoreCaseDataApi coreCaseDataApi;
@@ -388,6 +389,29 @@ public class CcdRetrievalServiceImplUTest {
         verify(authTokenGenerator).generate();
         verify(coreCaseDataApi)
             .readForCitizen(BEARER_AUTHORISATION, SERVICE_TOKEN, USER_ID, JURISDICTION_ID, CASE_TYPE,
+                testCaseId);
+    }
+
+    @Test
+    public void givenCaseId_whenRetrieveCaseByIdWithCaseworker_thenReturnTheCase() throws Exception {
+        String testCaseId = String.valueOf(CASE_ID_1);
+        CaseDetails caseDetails = CaseDetails.builder().build();
+
+        final UserDetails userDetails = UserDetails.builder()
+            .id(USER_ID).roles(Collections.singletonList(CASEWORKER_ROLE)).build();
+
+        when(userService.retrieveUserDetails(BEARER_AUTHORISATION)).thenReturn(userDetails);
+        when(authTokenGenerator.generate()).thenReturn(SERVICE_TOKEN);
+        when(coreCaseDataApi
+            .readForCaseWorker(BEARER_AUTHORISATION, SERVICE_TOKEN, USER_ID, JURISDICTION_ID, CASE_TYPE,
+                testCaseId)).thenReturn(caseDetails);
+
+        assertEquals(caseDetails, classUnderTest.retrieveCaseById(AUTHORISATION, testCaseId));
+
+        verify(userService).retrieveUserDetails(BEARER_AUTHORISATION);
+        verify(authTokenGenerator).generate();
+        verify(coreCaseDataApi)
+            .readForCaseWorker(BEARER_AUTHORISATION, SERVICE_TOKEN, USER_ID, JURISDICTION_ID, CASE_TYPE,
                 testCaseId);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdUpdateServiceImplUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdUpdateServiceImplUTest.java
@@ -16,6 +16,8 @@ import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.UserDetails;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.service.UserService;
 
+import java.util.Collections;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -25,6 +27,7 @@ public class CcdUpdateServiceImplUTest {
     private static final String JURISDICTION_ID = "someJurisdictionId";
     private static final String CASE_TYPE = "someCaseType";
     private static final String CREATE_EVENT_ID = "createEventId";
+    private static final String CASEWORKER_ROLE = "caseworker";
 
     private static final String DIVORCE_CASE_SUBMISSION_EVENT_SUMMARY =
         (String)ReflectionTestUtils.getField(CcdSubmissionServiceImpl.class,
@@ -96,6 +99,54 @@ public class CcdUpdateServiceImplUTest {
         verify(coreCaseDataApi).startEventForCitizen(bearerAuthorisation, serviceToken, userId, JURISDICTION_ID,
             CASE_TYPE, caseId, eventId);
         verify(coreCaseDataApi).submitEventForCitizen(bearerAuthorisation, serviceToken, userId, JURISDICTION_ID,
+            CASE_TYPE, caseId,true, caseDataContent);
+    }
+
+    @Test
+    public void whenUpdateWithCaseworker_thenProceedAsExpected() {
+        final String caseId = "caseId";
+        final String userId = "someUserId";
+        final String authorisation = "authorisation";
+        final String bearerAuthorisation = "Bearer authorisation";
+        final String serviceToken = "serviceToken";
+        final Object caseData = new Object();
+
+        final String eventId = "eventId";
+        final String token = "token";
+        final StartEventResponse startEventResponse = StartEventResponse.builder()
+            .eventId(eventId)
+            .token(token)
+            .build();
+
+        final CaseDataContent caseDataContent = CaseDataContent.builder()
+            .eventToken(startEventResponse.getToken())
+            .event(
+                Event.builder()
+                    .id(startEventResponse.getEventId())
+                    .summary(DIVORCE_CASE_SUBMISSION_EVENT_SUMMARY)
+                    .description(DIVORCE_CASE_SUBMISSION_EVENT_DESCRIPTION)
+                    .build()
+            ).data(caseData)
+            .build();
+
+        final UserDetails userDetails = UserDetails.builder().id(userId)
+            .roles(Collections.singletonList(CASEWORKER_ROLE)).build();
+        final CaseDetails expected = CaseDetails.builder().build();
+
+        when(userService.retrieveUserDetails(bearerAuthorisation)).thenReturn(userDetails);
+        when(authTokenGenerator.generate()).thenReturn(serviceToken);
+        when(coreCaseDataApi.startEventForCaseWorker(bearerAuthorisation, serviceToken, userId, JURISDICTION_ID,
+            CASE_TYPE, caseId, eventId)).thenReturn(startEventResponse);
+        when(coreCaseDataApi.submitEventForCaseWorker(bearerAuthorisation, serviceToken, userId, JURISDICTION_ID,
+            CASE_TYPE, caseId,true, caseDataContent)).thenReturn(expected);
+
+        CaseDetails actual = classUnderTest.update(caseId, caseData, eventId, authorisation);
+
+        assertEquals(actual, expected);
+
+        verify(coreCaseDataApi).startEventForCaseWorker(bearerAuthorisation, serviceToken, userId, JURISDICTION_ID,
+            CASE_TYPE, caseId, eventId);
+        verify(coreCaseDataApi).submitEventForCaseWorker(bearerAuthorisation, serviceToken, userId, JURISDICTION_ID,
             CASE_TYPE, caseId,true, caseDataContent);
     }
 }


### PR DESCRIPTION
[DIV-3645](https://tools.hmcts.net/jira/browse/DIV-3645)

Strategic Payment is being implemented in div-case-orchestration service on PR https://github.com/hmcts/div-case-orchestration-service/pull/126.

However, we use an anonymous caseworker user in order to update the case passed to us by pay team.
The request by Pay team does not have an authorisation token, so we must use a user ourselves. When updating a case, either the citizen who created the case or a caseworker is required, so we use an anonymous caseworker user.
However, the update flow in COS is reused, but it only supports the citizen path. This PR changes the retrieve case by ID and update case code so it checks the current user (which will be the anonymous caseworker) has the caseworker role, and if they do, run the caseworker path instead of the citizen path.
Edit: Now also checks that if the caseworker role is there, then make sure the citizen role isn't. If the citizen role is also there, use the citizen path instead.
Not foreseeing this scenario in actual tests, but our integration tests cheat a bit by using caseworker citizen users to perform certain actions. However, the CoreCaseData api will take the citizen role as a priority and return 403 when attempting to use the /caseworkers/ path instead of the /citizens/ path.