### PR TITLE
Force jackson-databind version 2.9.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,8 @@ def versions = [
     wiremockVersion: '2.8.0',
     pitest: '1.4.2',
     gradlePitest: '1.3.0',
-    sonarPitest: '0.5'
+    sonarPitest: '0.5',
+    jacksonDatabind: '2.9.8'
 ]
 
 dependencies {
@@ -144,6 +145,9 @@ dependencies {
 
     compile group: 'io.github.openfeign', name: 'feign-httpclient', version: versions.feignHttpClient
     compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: versions.reformSpringBootAutoConfigure
+    compile (group: 'com.fasterxml.jackson.core', name:'jackson-databind', version: versions.jacksonDatabind) {
+        force = true
+    }
 
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-json'
     compile group: 'com.puppycrawl.tools', name: 'checkstyle', version:  versions.puppyCrawl


### PR DESCRIPTION
# Description

Bumped up jackson-databind version 2.9.8 to fix CVE-2018-14718 vulnerability

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
