### PR TITLE
DIV-4133: Replaced old derived fields with new concatenated ones

### DIFF
--- a/src/integrationTest/resources/ccd-format-draft/addresscase.json
+++ b/src/integrationTest/resources/ccd-format-draft/addresscase.json
@@ -12,7 +12,7 @@
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",
-    "D8DerivedPetitionerCurrentFullName" :  "John Smith",
+    "PetitionerFullName" :  "John Smith",
     "D8PetitionerNameChangedHow" : [ "marriageCertificate" ],
     "D8PetitionerContactDetailsConfidential" : "share",
     "D8PetitionerHomeAddress" : {
@@ -38,8 +38,8 @@
     "D8PetitionerCorrespondenceUseHomeAddress" : "NO",
     "D8RespondentFirstName" : "Jane",
     "D8RespondentLastName" : "Jamed",
-    "D8DerivedRespondentCurrentName" : "Jane Jamed",
-    "D8DerivedRespondentSolicitorDetails" : "Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
+    "RespondentFullName" : "Jane Jamed",
+    "D8RespondentSolicitorDetails" : "Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
     "D8RespondentHomeAddress" : {
         "AddressLine3" : null,
         "AddressLine2" : null,

--- a/src/integrationTest/resources/ccd-submission-payload/addresses-no-hwf.json
+++ b/src/integrationTest/resources/ccd-submission-payload/addresses-no-hwf.json
@@ -12,7 +12,7 @@
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",
-    "D8DerivedPetitionerCurrentFullName":"John Smith",
+    "PetitionerFullName":"John Smith",
     "D8PetitionerNameChangedHow":[
         "marriageCertificate"
     ],
@@ -28,8 +28,8 @@
     "D8PetitionerCorrespondenceUseHomeAddress":"NO",
     "D8RespondentFirstName":"Jane",
     "D8RespondentLastName":"Jamed",
-    "D8DerivedRespondentCurrentName":"Jane Jamed",
-    "D8DerivedRespondentSolicitorDetails":"Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
+    "RespondentFullName":"Jane Jamed",
+    "D8RespondentSolicitorDetails":"Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
     "D8RespondentHomeAddress":{
         "PostCode":"SS SSS"
     },

--- a/src/integrationTest/resources/ccd-submission-payload/addresses.json
+++ b/src/integrationTest/resources/ccd-submission-payload/addresses.json
@@ -12,7 +12,7 @@
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",
-    "D8DerivedPetitionerCurrentFullName":"John Smith",
+    "PetitionerFullName":"John Smith",
     "D8PetitionerNameChangedHow":[
         "marriageCertificate"
     ],
@@ -28,8 +28,8 @@
     "D8PetitionerCorrespondenceUseHomeAddress":"NO",
     "D8RespondentFirstName":"Jane",
     "D8RespondentLastName":"Jamed",
-    "D8DerivedRespondentCurrentName":"Jane Jamed",
-    "D8DerivedRespondentSolicitorDetails":"Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
+    "RespondentFullName":"Jane Jamed",
+    "D8RespondentSolicitorDetails":"Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
     "D8RespondentHomeAddress":{
         "PostCode":"SS SSS"
     },

--- a/src/integrationTest/resources/ccd-submission-payload/d8-document.json
+++ b/src/integrationTest/resources/ccd-submission-payload/d8-document.json
@@ -13,7 +13,7 @@
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",
-    "D8DerivedPetitionerCurrentFullName":"John Smith",
+    "PetitionerFullName":"John Smith",
     "D8PetitionerNameChangedHow":[
         "marriageCertificate"
     ],
@@ -29,7 +29,7 @@
     "D8PetitionerCorrespondenceUseHomeAddress":"YES",
     "D8RespondentFirstName":"Jane",
     "D8RespondentLastName":"Jamed",
-    "D8DerivedRespondentCurrentName":"Jane Jamed",
+    "RespondentFullName":"Jane Jamed",
     "D8RespondentHomeAddress":{
         "PostCode":"SW9 9PE"
     },

--- a/src/integrationTest/resources/ccd-submission-payload/how-name-changed.json
+++ b/src/integrationTest/resources/ccd-submission-payload/how-name-changed.json
@@ -12,7 +12,7 @@
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",
-    "D8DerivedPetitionerCurrentFullName":"John Smith",
+    "PetitionerFullName":"John Smith",
     "D8PetitionerNameChangedHow":[
         "marriageCertificate",
         "deedPoll",
@@ -31,7 +31,7 @@
     "D8PetitionerCorrespondenceUseHomeAddress":"YES",
     "D8RespondentFirstName":"Jane",
     "D8RespondentLastName":"Jamed",
-    "D8DerivedRespondentCurrentName":"Jane Jamed",
+    "RespondentFullName":"Jane Jamed",
     "D8RespondentHomeAddress":{
         "PostCode":"SW9 9PE"
     },

--- a/src/integrationTest/resources/ccd-submission-payload/jurisdiction-6-12.json
+++ b/src/integrationTest/resources/ccd-submission-payload/jurisdiction-6-12.json
@@ -12,7 +12,7 @@
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",
-    "D8DerivedPetitionerCurrentFullName":"John Smith",
+    "PetitionerFullName":"John Smith",
     "D8PetitionerNameChangedHow":[
         "marriageCertificate"
     ],
@@ -28,7 +28,7 @@
     "D8PetitionerCorrespondenceUseHomeAddress":"YES",
     "D8RespondentFirstName":"Jane",
     "D8RespondentLastName":"Jamed",
-    "D8DerivedRespondentCurrentName":"Jane Jamed",
+    "RespondentFullName":"Jane Jamed",
     "D8RespondentHomeAddress":{
         "PostCode":"SW9 9PE"
     },

--- a/src/integrationTest/resources/ccd-submission-payload/jurisdiction-all.json
+++ b/src/integrationTest/resources/ccd-submission-payload/jurisdiction-all.json
@@ -12,7 +12,7 @@
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",
-    "D8DerivedPetitionerCurrentFullName":"John Smith",
+    "PetitionerFullName":"John Smith",
     "D8PetitionerNameChangedHow":[
         "marriageCertificate"
     ],
@@ -28,7 +28,7 @@
     "D8PetitionerCorrespondenceUseHomeAddress":"YES",
     "D8RespondentFirstName":"Jane",
     "D8RespondentLastName":"Jamed",
-    "D8DerivedRespondentCurrentName":"Jane Jamed",
+    "RespondentFullName":"Jane Jamed",
     "D8RespondentHomeAddress":{
         "PostCode":"SW9 9PE"
     },

--- a/src/integrationTest/resources/ccd-submission-payload/linked-case.json
+++ b/src/integrationTest/resources/ccd-submission-payload/linked-case.json
@@ -12,7 +12,7 @@
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",
-    "D8DerivedPetitionerCurrentFullName":"John Smith",
+    "PetitionerFullName":"John Smith",
     "D8PetitionerNameChangedHow":[
         "marriageCertificate"
     ],
@@ -28,8 +28,8 @@
     "D8PetitionerCorrespondenceUseHomeAddress":"NO",
     "D8RespondentFirstName":"Jane",
     "D8RespondentLastName":"Jamed",
-    "D8DerivedRespondentCurrentName":"Jane Jamed",
-    "D8DerivedRespondentSolicitorDetails":"Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
+    "RespondentFullName":"Jane Jamed",
+    "D8RespondentSolicitorDetails":"Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
     "D8RespondentHomeAddress":{
         "PostCode":"SS SSS"
     },

--- a/src/integrationTest/resources/ccd-submission-payload/reason-adultery.json
+++ b/src/integrationTest/resources/ccd-submission-payload/reason-adultery.json
@@ -12,7 +12,7 @@
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",
-    "D8DerivedPetitionerCurrentFullName":"John Smith",
+    "PetitionerFullName":"John Smith",
     "D8PetitionerNameChangedHow":[
         "marriageCertificate"
     ],
@@ -28,7 +28,7 @@
     "D8PetitionerCorrespondenceUseHomeAddress":"YES",
     "D8RespondentFirstName":"Jane",
     "D8RespondentLastName":"Jamed",
-    "D8DerivedRespondentCurrentName":"Jane Jamed",
+    "RespondentFullName":"Jane Jamed",
     "D8RespondentHomeAddress":{
         "PostCode":"SW9 9PE"
     },
@@ -87,7 +87,7 @@
     "D8MarriageCanDivorce":"YES",
     "D8MarriagePetitionerName":"John Doe",
     "D8MarriageRespondentName":"Jenny Benny",
-    "D8DerivedReasonForDivorceAdultery3dPtyNm":"Jennifer Lawrence",
+    "CoRespondentFullName":"Jennifer Lawry",
     "D8Connections":{
         "A":"The Petitioner and the Respondent are habitually resident in England and Wales",
         "C":"The Respondent is habitually resident in England and Wales"
@@ -95,7 +95,7 @@
     "D8ReasonForDivorceHasMarriage":"YES",
     "D8ReasonForDivorceShowFiveYearsSeparatio":"YES",
     "D8ReasonForDivorceClaiming5YearSeparatio":"NO",
-    "D8DerivedReasonForDivorceAdultery3rdAddr":"Headquarters 1120 N Street Sacramento 916-654-5266\t\nP.O. Box 942873 Sacramento, CA 94273-0001",
+    "D8ReasonForDivorceAdultery3rdAddress":"Headquarters 1120 N Street Sacramento 916-654-5266\t\nP.O. Box 942873 Sacramento, CA 94273-0001",
     "D8Cohort":"onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender":"female",
     "D8InferredRespondentGender":"male"

--- a/src/integrationTest/resources/ccd-submission-payload/reason-desertion.json
+++ b/src/integrationTest/resources/ccd-submission-payload/reason-desertion.json
@@ -12,7 +12,7 @@
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",
-    "D8DerivedPetitionerCurrentFullName":"John Smith",
+    "PetitionerFullName":"John Smith",
     "D8PetitionerNameChangedHow":[
         "marriageCertificate"
     ],
@@ -28,7 +28,7 @@
     "D8PetitionerCorrespondenceUseHomeAddress":"YES",
     "D8RespondentFirstName":"Jane",
     "D8RespondentLastName":"Jamed",
-    "D8DerivedRespondentCurrentName":"Jane Jamed",
+    "RespondentFullName":"Jane Jamed",
     "D8RespondentHomeAddress":{
         "PostCode":"SW9 9PE"
     },

--- a/src/integrationTest/resources/ccd-submission-payload/reason-separation.json
+++ b/src/integrationTest/resources/ccd-submission-payload/reason-separation.json
@@ -12,7 +12,7 @@
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",
-    "D8DerivedPetitionerCurrentFullName":"John Smith",
+    "PetitionerFullName":"John Smith",
     "D8PetitionerNameChangedHow":[
         "marriageCertificate"
     ],
@@ -28,7 +28,7 @@
     "D8PetitionerCorrespondenceUseHomeAddress":"YES",
     "D8RespondentFirstName":"Jane",
     "D8RespondentLastName":"Jamed",
-    "D8DerivedRespondentCurrentName":"Jane Jamed",
+    "RespondentFullName":"Jane Jamed",
     "D8RespondentHomeAddress":{
         "PostCode":"SW9 9PE"
     },

--- a/src/integrationTest/resources/ccd-submission-payload/reason-unreasonable-behaviour.json
+++ b/src/integrationTest/resources/ccd-submission-payload/reason-unreasonable-behaviour.json
@@ -12,7 +12,7 @@
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",
-    "D8DerivedPetitionerCurrentFullName":"John Smith",
+    "PetitionerFullName":"John Smith",
     "D8PetitionerNameChangedHow":[
         "marriageCertificate"
     ],
@@ -28,7 +28,7 @@
     "D8PetitionerCorrespondenceUseHomeAddress":"YES",
     "D8RespondentFirstName":"Jane",
     "D8RespondentLastName":"Jamed",
-    "D8DerivedRespondentCurrentName":"Jane Jamed",
+    "RespondentFullName":"Jane Jamed",
     "D8RespondentHomeAddress":{
         "PostCode":"SW9 9PE"
     },

--- a/src/integrationTest/resources/ccd-submission-payload/same-sex.json
+++ b/src/integrationTest/resources/ccd-submission-payload/same-sex.json
@@ -12,7 +12,7 @@
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",
-    "D8DerivedPetitionerCurrentFullName":"John Smith",
+    "PetitionerFullName":"John Smith",
     "D8PetitionerNameChangedHow":[
         "marriageCertificate"
     ],
@@ -28,7 +28,7 @@
     "D8PetitionerCorrespondenceUseHomeAddress":"YES",
     "D8RespondentFirstName":"Jane",
     "D8RespondentLastName":"Jamed",
-    "D8DerivedRespondentCurrentName":"Jane Jamed",
+    "RespondentFullName":"Jane Jamed",
     "D8RespondentHomeAddress":{
         "PostCode":"SW9 9PE"
     },

--- a/src/integrationTest/resources/ccd-update-payload/update-addresses.json
+++ b/src/integrationTest/resources/ccd-update-payload/update-addresses.json
@@ -12,7 +12,7 @@
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",
-    "D8DerivedPetitionerCurrentFullName":"John Smith",
+    "PetitionerFullName":"John Smith",
     "D8PetitionerNameChangedHow":[
         "marriageCertificate"
     ],
@@ -28,8 +28,8 @@
     "D8PetitionerCorrespondenceUseHomeAddress":"NO",
     "D8RespondentFirstName":"Jane",
     "D8RespondentLastName":"Jamed",
-    "D8DerivedRespondentCurrentName":"Jane Jamed",
-    "D8DerivedRespondentSolicitorDetails":"Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
+    "RespondentFullName":"Jane Jamed",
+    "D8RespondentSolicitorDetails":"Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
     "D8RespondentHomeAddress":{
         "PostCode":"SS SSS"
     },

--- a/src/test/resources/ccd-submission-payload/addresses-no-hwf.json
+++ b/src/test/resources/ccd-submission-payload/addresses-no-hwf.json
@@ -12,7 +12,7 @@
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",
-    "D8DerivedPetitionerCurrentFullName":"John Smith",
+    "PetitionerFullName":"John Smith",
     "D8PetitionerNameChangedHow":[
         "marriageCertificate"
     ],
@@ -28,8 +28,8 @@
     "D8PetitionerCorrespondenceUseHomeAddress":"NO",
     "D8RespondentFirstName":"Jane",
     "D8RespondentLastName":"Jamed",
-    "D8DerivedRespondentCurrentName":"Jane Jamed",
-    "D8DerivedRespondentSolicitorDetails":"Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
+    "RespondentFullName":"Jane Jamed",
+    "D8RespondentSolicitorDetails":"Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
     "D8RespondentHomeAddress":{
         "PostCode":"SS SSS"
     },

--- a/src/test/resources/ccd-submission-payload/addresses.json
+++ b/src/test/resources/ccd-submission-payload/addresses.json
@@ -12,7 +12,7 @@
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",
-    "D8DerivedPetitionerCurrentFullName":"John Smith",
+    "PetitionerFullName":"John Smith",
     "D8PetitionerNameChangedHow":[
         "marriageCertificate"
     ],
@@ -28,8 +28,8 @@
     "D8PetitionerCorrespondenceUseHomeAddress":"NO",
     "D8RespondentFirstName":"Jane",
     "D8RespondentLastName":"Jamed",
-    "D8DerivedRespondentCurrentName":"Jane Jamed",
-    "D8DerivedRespondentSolicitorDetails":"Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
+    "RespondentFullName":"Jane Jamed",
+    "D8RespondentSolicitorDetails":"Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
     "D8RespondentHomeAddress":{
         "PostCode":"SS SSS"
     },


### PR DESCRIPTION
DIV-4133 Replace old Derived fields with new Concatenated fields

Changed from: D8DerivedReasonForDivorceAdultery3dPtyNm -> CoRespondentFullName D8DerivedRespondentSolicitorDetails -> D8RespondentSolicitorDetails D8DerivedRespondentCurrentName -> RespondentFullName 
D8DerivedPetitionerCurrentFullName -> PetitionerFullName D8DerivedReasonForDivorceAdultery3rdAddr -> D8ReasonForDivorceAdultery3rdAddress