### PR TITLE
DIV-4252: Fixing production error

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/petition/CcdRetrieveAosCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/petition/CcdRetrieveAosCaseTest.java
@@ -6,14 +6,15 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.divorce.support.PetitionSupport;
 
+import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 
 public class CcdRetrieveAosCaseTest extends PetitionSupport {
-    private static final String INVALID_USER_TOKEN = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIwOTg3NjU0M"
-        + "yIsInN1YiI6IjEwMCIsImlhdCI6MTUwODk0MDU3MywiZXhwIjoxNTE5MzAzNDI3LCJkYXRhIjoiY2l0aXplbiIsInR5cGUiOiJBQ0NFU1MiL"
-        + "CJpZCI6IjEwMCIsImZvcmVuYW1lIjoiSm9obiIsInN1cm5hbWUiOiJEb2UiLCJkZWZhdWx0LXNlcnZpY2UiOiJEaXZvcmNlIiwibG9hIjoxL"
-        + "CJkZWZhdWx0LXVybCI6Imh0dHBzOi8vd3d3Lmdvdi51ayIsImdyb3VwIjoiZGl2b3JjZSJ9.lkNr1vpAP5_Gu97TQa0cRtHu8I-QESzu8kMX"
-        + "CJOQrVU";
+    private static final String INVALID_USER_TOKEN = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIwO"
+            + "Tg3NjU0MyIsInN1YiI6IjEwMCIsImlhdCI6MTUwODk0MDU3MywiZXhwIjoxNTE5MzAzNDI3LCJkYXRhIjoiY2l0aXplbiIsInR"
+            + "5cGUiOiJBQ0NFU1MiLCJpZCI6IjEwMCIsImZvcmVuYW1lIjoiSm9obiIsInN1cm5hbWUiOiJEb2UiLCJkZWZhdWx0LXNlcnZpY"
+            + "2UiOiJEaXZvcmNlIiwibG9hIjoxLCJkZWZhdWx0LXVybCI6Imh0dHBzOi8vd3d3Lmdvdi51ayIsImdyb3VwIjoiZGl2b3JjZSJ"
+            + "9.lkNr1vpAP5_Gu97TQa0cRtHu8I-QESzu8kMXCJOQrVU";
 
     private static final String TEST_AOS_RESPONDED_EVENT = "testAosStarted";
     private static final String TEST_AOS_AWAITING_DN = "testAwaitingDecreeNisi";
@@ -44,6 +45,22 @@ public class CcdRetrieveAosCaseTest extends PetitionSupport {
     }
 
     @Test
+    public void whenUserAlreadyHasDraftSaved_AndTriesToLogInAsRespondent_ThenCaseIsNotFound() throws Exception {
+        //Create a draft
+        final String userToken = getUserToken();
+        final String filePath = DIVORCE_FORMAT_DRAFT_CONTEXT_PATH + "addresses.json";
+        Response draftCreationResponse = createDraft(userToken, filePath, singletonMap(DIVORCE_FORMAT_KEY, "true"));
+        assertEquals(HttpStatus.OK.value(), draftCreationResponse.getStatusCode());
+
+        //Query AOS case
+        Response cmsResponse = retrieveCase(userToken, true);
+
+        //Response should be not found
+        assertEquals(HttpStatus.NO_CONTENT.value(), cmsResponse.getStatusCode());
+        assertEquals(cmsResponse.asString(), "");
+    }
+
+    @Test
     public void givenOneAosRespondedCaseInCcd_whenRetrieveAosCase_thenReturnTheCase() throws Exception {
         final String userToken = getUserToken();
 
@@ -52,7 +69,7 @@ public class CcdRetrieveAosCaseTest extends PetitionSupport {
         Response cmsResponse = retrieveCase(userToken, true);
 
         assertEquals(HttpStatus.OK.value(), cmsResponse.getStatusCode());
-        assertEquals((Long)createCaseResponse.path("id"), cmsResponse.path("id"));
+        assertEquals((Long) createCaseResponse.path("id"), cmsResponse.path("id"));
     }
 
     @Test
@@ -66,12 +83,12 @@ public class CcdRetrieveAosCaseTest extends PetitionSupport {
         Response cmsResponse = retrieveCase(userToken, true);
 
         assertEquals(HttpStatus.OK.value(), cmsResponse.getStatusCode());
-        assertEquals((Long)createCaseResponse.path("id"), cmsResponse.path("id"));
+        assertEquals((Long) createCaseResponse.path("id"), cmsResponse.path("id"));
     }
 
     @Test
     public void givenMultipleCompletedAndOtherCaseInCcd_whenRetrieveAosCase_thenReturnFirstCompletedCase()
-        throws Exception {
+            throws Exception {
         final String userToken = getUserToken();
 
         getCaseIdFromSubmittingANewCase(userToken);
@@ -83,7 +100,7 @@ public class CcdRetrieveAosCaseTest extends PetitionSupport {
         Response cmsResponse = retrieveCase(userToken, true);
 
         assertEquals(HttpStatus.OK.value(), cmsResponse.getStatusCode());
-        assertEquals((Long)createCaseResponse.path("id"), cmsResponse.path("id"));
+        assertEquals((Long) createCaseResponse.path("id"), cmsResponse.path("id"));
     }
 
     @Test
@@ -100,7 +117,7 @@ public class CcdRetrieveAosCaseTest extends PetitionSupport {
 
     @Test
     public void givenMultipleAosStartedAndNoAosCompletedCaseInCcd_whenRetrieveAosCase_thenReturnMultipleChoice()
-        throws Exception {
+            throws Exception {
         final String userToken = getUserToken();
 
         createACaseUpdateStateAndReturnTheCase(userToken, TEST_AOS_RESPONDED_EVENT).path("id");
@@ -126,7 +143,7 @@ public class CcdRetrieveAosCaseTest extends PetitionSupport {
     private Response createACaseUpdateStateAndReturnTheCase(String userToken, String eventName) throws Exception {
         Long caseId = getCaseIdFromSubmittingANewCase(userToken);
 
-        return updateCase((String)null, caseId, eventName, userToken);
+        return updateCase((String) null, caseId, eventName, userToken);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/PetitionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/PetitionService.java
@@ -15,6 +15,8 @@ public interface PetitionService {
 
     CaseDetails retrievePetition(String authorisation) throws DuplicateCaseException;
 
+    CaseDetails retrievePetitionForAos(String authorisation) throws DuplicateCaseException;
+
     CaseDetails retrievePetitionByCaseId(String authorisation, String caseId);
 
     void saveDraft(String authorisation, Map<String, Object> data, boolean divorceFormat);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/PetitionServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/PetitionServiceImpl.java
@@ -25,7 +25,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import javax.annotation.Nonnull;
+
+import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CaseRetrievalStateMap.RESPONDENT_CASE_STATE_GROUPING;
 
 @Service
 @Slf4j
@@ -71,6 +74,11 @@ public class PetitionServiceImpl implements PetitionService,
     @Override
     public CaseDetails retrievePetition(String authorisation) throws DuplicateCaseException {
         return ccdRetrievalService.retrieveCase(authorisation);
+    }
+
+    @Override
+    public CaseDetails retrievePetitionForAos(String authorisation) throws DuplicateCaseException {
+        return ccdRetrievalService.retrieveCase(authorisation, RESPONDENT_CASE_STATE_GROUPING);
     }
 
     @Override

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/PetitionControllerUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/PetitionControllerUTest.java
@@ -13,7 +13,6 @@ import uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.DivorceSe
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.draftstore.model.DraftList;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception.DuplicateCaseException;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.service.PetitionService;
-import util.ReflectionTestUtil;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -28,7 +27,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CaseRetrievalStateMap.PETITIONER_CASE_STATE_GROUPING;
-import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CaseRetrievalStateMap.RESPONDENT_CASE_STATE_GROUPING;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PetitionControllerUTest {
@@ -50,7 +48,7 @@ public class PetitionControllerUTest {
         final CaseDetails caseDetails = CaseDetails.builder().build();
 
         when(petitionService.retrievePetition(AUTHORISATION, PETITIONER_CASE_STATE_GROUPING, checkCcd))
-            .thenReturn(caseDetails);
+                .thenReturn(caseDetails);
 
         ResponseEntity<CaseDetails> actual = classUnderTest.retrievePetition(AUTHORISATION, checkCcd);
 
@@ -63,19 +61,16 @@ public class PetitionControllerUTest {
     @Test
     public void givenCaseFound_whenRetrieveCaseForRespondent_thenReturnCaseDetails() throws DuplicateCaseException {
 
-        final boolean checkCcd = true;
-
         final CaseDetails caseDetails = CaseDetails.builder().build();
 
-        when(petitionService.retrievePetition(AUTHORISATION, RESPONDENT_CASE_STATE_GROUPING, checkCcd))
-            .thenReturn(caseDetails);
+        when(petitionService.retrievePetitionForAos(AUTHORISATION)).thenReturn(caseDetails);
 
-        ResponseEntity<CaseDetails> actual = classUnderTest.retrieveCaseForRespondent(AUTHORISATION, checkCcd);
+        ResponseEntity<CaseDetails> actual = classUnderTest.retrieveCaseForRespondent(AUTHORISATION);
 
         assertEquals(HttpStatus.OK, actual.getStatusCode());
         assertEquals(caseDetails, actual.getBody());
 
-        verify(petitionService).retrievePetition(AUTHORISATION, RESPONDENT_CASE_STATE_GROUPING, checkCcd);
+        verify(petitionService).retrievePetitionForAos(AUTHORISATION);
     }
 
     @Test
@@ -86,9 +81,9 @@ public class PetitionControllerUTest {
         final CaseDetails caseDetails = CaseDetails.builder().build();
 
         when(petitionService.retrievePetition(AUTHORISATION, PETITIONER_CASE_STATE_GROUPING, checkCcd))
-            .thenReturn(caseDetails);
+                .thenReturn(caseDetails);
 
-        ResponseEntity<CaseDetails> actual = retrieveCase(checkCcd);
+        ResponseEntity<CaseDetails> actual = classUnderTest.retrievePetition(AUTHORISATION, checkCcd);
 
         assertEquals(HttpStatus.OK, actual.getStatusCode());
         assertEquals(caseDetails, actual.getBody());
@@ -104,14 +99,14 @@ public class PetitionControllerUTest {
         final CaseDetails caseDetails = CaseDetails.builder().build();
 
         when(petitionService.retrievePetition(AUTHORISATION, PETITIONER_CASE_STATE_GROUPING, false))
-            .thenReturn(caseDetails);
+                .thenReturn(caseDetails);
 
-        ResponseEntity<CaseDetails> actual = retrieveCase(checkCcd);
+        ResponseEntity<CaseDetails> actual = classUnderTest.retrievePetition(AUTHORISATION, checkCcd);
 
         assertEquals(HttpStatus.OK, actual.getStatusCode());
         assertEquals(caseDetails, actual.getBody());
 
-        verify(petitionService).retrievePetition(AUTHORISATION, PETITIONER_CASE_STATE_GROUPING,false);
+        verify(petitionService).retrievePetition(AUTHORISATION, PETITIONER_CASE_STATE_GROUPING, false);
     }
 
     @Test
@@ -120,9 +115,9 @@ public class PetitionControllerUTest {
         final boolean checkCcd = true;
 
         when(petitionService.retrievePetition(AUTHORISATION, PETITIONER_CASE_STATE_GROUPING, checkCcd))
-            .thenReturn(null);
+                .thenReturn(null);
 
-        ResponseEntity<CaseDetails> actual = retrieveCase(checkCcd);
+        ResponseEntity<CaseDetails> actual = classUnderTest.retrievePetition(AUTHORISATION, checkCcd);
 
         assertEquals(HttpStatus.NO_CONTENT, actual.getStatusCode());
         assertNull(actual.getBody());
@@ -135,9 +130,9 @@ public class PetitionControllerUTest {
         final boolean checkCcd = true;
 
         when(petitionService.retrievePetition(AUTHORISATION, PETITIONER_CASE_STATE_GROUPING, checkCcd))
-            .thenThrow(new DuplicateCaseException("Duplicate"));
+                .thenThrow(new DuplicateCaseException("Duplicate"));
 
-        ResponseEntity<CaseDetails> actual = retrieveCase(checkCcd);
+        ResponseEntity<CaseDetails> actual = classUnderTest.retrievePetition(AUTHORISATION, checkCcd);
 
         assertEquals(HttpStatus.MULTIPLE_CHOICES, actual.getStatusCode());
 
@@ -343,14 +338,5 @@ public class PetitionControllerUTest {
         assertEquals(draftData, actual.getBody());
 
         verify(petitionService).createAmendedPetitionDraft(AUTHORISATION);
-    }
-
-    private ResponseEntity<CaseDetails> retrieveCase(Boolean checkCcd) {
-        try {
-            return ReflectionTestUtil.invokeMethod(classUnderTest, "retrieveCase", AUTHORISATION,
-                PETITIONER_CASE_STATE_GROUPING, checkCcd);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrieveAosCaseITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/RetrieveAosCaseITest.java
@@ -42,6 +42,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.text.IsEmptyString.isEmptyOrNullString;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
@@ -355,7 +356,7 @@ public class RetrieveAosCaseITest extends AuthIdamMockSupport {
     }
 
     @Test
-    public void givenNoCaseInCcdAndOneDraftInStore_whenRetrieveAosCase_thenReturnFormattedDraft() throws Exception {
+    public void givenNoCaseInCcdAndOneDraftInStore_whenRetrieveAosCase_thenReturnNoContentResponse() throws Exception {
         final String message = getUserDetails();
         final String serviceToken = "serviceToken";
 
@@ -374,17 +375,13 @@ public class RetrieveAosCaseITest extends AuthIdamMockSupport {
 
         webClient.perform(MockMvcRequestBuilders.get(API_URL)
             .header(HttpHeaders.AUTHORIZATION, USER_TOKEN)
-            .param(CHECK_CCD_PARAM, "true")
             .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().json(ObjectMapperTestUtil.convertObjectToJsonString(CaseDetails
-                .builder()
-                .data(new HashMap<>())
-                .build())));
+            .andExpect(status().isNoContent())
+            .andExpect(content().string(isEmptyOrNullString()));
     }
 
     @Test
-    public void givenNoCaseInCcdAndOneDraftInStoreInDivorceFormat_whenRetrieveAosCase_thenReturnFormattedDraft()
+    public void givenNoCaseInCcdAndOneDraftInStoreInDivorceFormat_whenRetrieveAosCase_thenReturnNoContentResponse()
         throws Exception {
         final String message = getUserDetails();
         final String serviceToken = "serviceToken";
@@ -395,8 +392,6 @@ public class RetrieveAosCaseITest extends AuthIdamMockSupport {
         final DraftList draftList = new DraftList(Collections.singletonList(
             new Draft("1", divorceSessionData, DRAFT_DOCUMENT_TYPE_DIVORCE_FORMAT)),
             null);
-
-        final CaseDetails caseDetails = CaseDetails.builder().data(caseData).build();
 
         stubUserDetailsEndpoint(HttpStatus.OK, new EqualToPattern(USER_TOKEN), message);
 
@@ -413,14 +408,13 @@ public class RetrieveAosCaseITest extends AuthIdamMockSupport {
 
         webClient.perform(MockMvcRequestBuilders.get(API_URL)
             .header(HttpHeaders.AUTHORIZATION, USER_TOKEN)
-            .param(CHECK_CCD_PARAM, "true")
             .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().json(ObjectMapperTestUtil.convertObjectToJsonString(caseDetails)));
+            .andExpect(status().isNoContent())
+            .andExpect(content().string(isEmptyOrNullString()));
     }
 
     @Test
-    public void givenDoNotCheckCcdAndMultipleDraftInStore_whenRetrieveAosCase_thenReturnFormattedDraft() throws Exception {
+    public void givenDoNotCheckCcdAndMultipleDraftInStore_whenRetrieveAosCase_thenReturnNoContentResponse() throws Exception {
         final String message = getUserDetails();
         final String serviceToken = "serviceToken";
 
@@ -438,13 +432,9 @@ public class RetrieveAosCaseITest extends AuthIdamMockSupport {
 
         webClient.perform(MockMvcRequestBuilders.get(API_URL)
             .header(HttpHeaders.AUTHORIZATION, USER_TOKEN)
-            .param(CHECK_CCD_PARAM, "false")
             .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().json(ObjectMapperTestUtil.convertObjectToJsonString(CaseDetails
-                .builder()
-                .data(new HashMap<>())
-                .build())));
+            .andExpect(status().isNoContent())
+            .andExpect(content().string(isEmptyOrNullString()));
     }
 
     private void stubGetDraftEndpoint(StringValuePattern authHeader, StringValuePattern serviceToken, String message) {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdRetrievalServiceImplUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdRetrievalServiceImplUTest.java
@@ -16,7 +16,6 @@ import uk.gov.hmcts.reform.divorce.casemaintenanceservice.draftstore.domain.mode
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception.DuplicateCaseException;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.service.UserService;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
For retrieving case for respondent, we shouldn't care whether that user has a saved draft

# Description

If a respondent already has a draft saved, CMS is retrieving that draft. However, as a respondent this feature should not be available.

Fixes # DIV-4252

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Updated unit tests and integration tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
