### PR TITLE
DIV-4437 Linking respondents no longer check AoS Received

### DIFF
--- a/src/integrationTest/resources/ccd-submission-payload/linked-case.json
+++ b/src/integrationTest/resources/ccd-submission-payload/linked-case.json
@@ -93,7 +93,5 @@
     "D8ReasonForDivorceClaiming5YearSeparatio":"NO",
     "D8Cohort":"onlineSubmissionPrivateBeta",
     "D8InferredPetitionerGender":"female",
-    "D8InferredRespondentGender":"male",
-    "ReceivedAOSfromResp": "YES",
-    "ReceivedAosFromCoResp": "YES"
+    "D8InferredRespondentGender":"male"
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/CcdController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/CcdController.java
@@ -71,9 +71,10 @@ public class CcdController {
     @PostMapping(path = "/link-respondent/{caseId}/{letterHolderId}")
     @ApiOperation(value = "Updates case details")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "Returned when case with id and letter holder id exists and the access is "
-            + "granted to the respondent user"),
-        @ApiResponse(code = 404, message = "Returned when case with id not found or letter holder id doesn't match"),
+        @ApiResponse(code = 200, message = "Returned when case with id and letter holder id exists and the access is granted to the respondent user"),
+        @ApiResponse(code = 404, message = "Returned when case with id not found"),
+        @ApiResponse(code = 400, message = "Returned when data is missing from request or case"),
+        @ApiResponse(code = 401, message = "Returned when case letter holder ID does not match corresponding case data or case is already linked"),
         }
     )
     public ResponseEntity<Void> linkRespondent(

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/support/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/support/GlobalExceptionHandler.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception.CaseNotFoundException;
+import uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception.InvalidRequestException;
+import uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception.UnauthorizedException;
 
 @ControllerAdvice
 @Slf4j
@@ -25,6 +27,20 @@ public class GlobalExceptionHandler {
         log.warn(exception.getMessage(), exception);
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exception.getMessage());
+    }
+
+    @ExceptionHandler(InvalidRequestException.class)
+    ResponseEntity<Object> handleInvalidRequestException(InvalidRequestException exception) {
+        log.warn(exception.getMessage(), exception);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exception.getMessage());
+    }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    ResponseEntity<Object> handleUnauthorizedException(InvalidRequestException exception) {
+        log.warn(exception.getMessage(), exception);
+
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(exception.getMessage());
     }
 
     @ExceptionHandler(HttpClientErrorException.class)

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/support/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/support/GlobalExceptionHandler.java
@@ -7,9 +7,6 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception.BaseException;
-import uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception.CaseNotFoundException;
-import uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception.InvalidRequestException;
-import uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception.UnauthorizedException;
 
 @ControllerAdvice
 @Slf4j
@@ -22,7 +19,7 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(exception.status()).body(exception.getMessage());
     }
 
-    @ExceptionHandler({CaseNotFoundException.class, InvalidRequestException.class, UnauthorizedException.class})
+    @ExceptionHandler(BaseException.class)
     ResponseEntity<Object> handleApplicationException(BaseException exception) {
         log.warn(exception.getMessage(), exception);
 

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/support/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/support/GlobalExceptionHandler.java
@@ -2,11 +2,11 @@ package uk.gov.hmcts.reform.divorce.casemaintenanceservice.controller.support;
 
 import feign.FeignException;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.client.HttpClientErrorException;
+import uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception.BaseException;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception.CaseNotFoundException;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception.InvalidRequestException;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception.UnauthorizedException;
@@ -22,25 +22,11 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(exception.status()).body(exception.getMessage());
     }
 
-    @ExceptionHandler(CaseNotFoundException.class)
-    ResponseEntity<Object> handleCaseNotFoundException(CaseNotFoundException exception) {
+    @ExceptionHandler({CaseNotFoundException.class, InvalidRequestException.class, UnauthorizedException.class})
+    ResponseEntity<Object> handleApplicationException(BaseException exception) {
         log.warn(exception.getMessage(), exception);
 
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exception.getMessage());
-    }
-
-    @ExceptionHandler(InvalidRequestException.class)
-    ResponseEntity<Object> handleInvalidRequestException(InvalidRequestException exception) {
-        log.warn(exception.getMessage(), exception);
-
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exception.getMessage());
-    }
-
-    @ExceptionHandler(UnauthorizedException.class)
-    ResponseEntity<Object> handleUnauthorizedException(InvalidRequestException exception) {
-        log.warn(exception.getMessage(), exception);
-
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(exception.getMessage());
+        return exception.getResponse();
     }
 
     @ExceptionHandler(HttpClientErrorException.class)

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/BaseException.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/BaseException.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public abstract class BaseException extends RuntimeException {
+    public HttpStatus status;
+
+    BaseException(String message) {
+        super(message);
+    }
+
+    public ResponseEntity<Object> getResponse() {
+        return ResponseEntity.status(status).body(this.getMessage());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/BaseException.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/BaseException.java
@@ -1,16 +1,15 @@
 package uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception;
 
-import lombok.Setter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 public abstract class BaseException extends RuntimeException {
 
-    @Setter
-    private HttpStatus status;
+    private final HttpStatus status;
 
-    BaseException(String message) {
+    BaseException(String message, HttpStatus httpStatus) {
         super(message);
+        this.status = httpStatus;
     }
 
     public ResponseEntity<Object> getResponse() {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/BaseException.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/BaseException.java
@@ -1,10 +1,13 @@
 package uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception;
 
+import lombok.Setter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 public abstract class BaseException extends RuntimeException {
-    public HttpStatus status;
+
+    @Setter
+    private HttpStatus status;
 
     BaseException(String message) {
         super(message);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/CaseNotFoundException.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/CaseNotFoundException.java
@@ -5,6 +5,6 @@ import org.springframework.http.HttpStatus;
 public class CaseNotFoundException extends BaseException {
     public CaseNotFoundException(String message) {
         super(message);
-        this.status = HttpStatus.NOT_FOUND;
+        this.setStatus(HttpStatus.NOT_FOUND);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/CaseNotFoundException.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/CaseNotFoundException.java
@@ -4,7 +4,6 @@ import org.springframework.http.HttpStatus;
 
 public class CaseNotFoundException extends BaseException {
     public CaseNotFoundException(String message) {
-        super(message);
-        this.setStatus(HttpStatus.NOT_FOUND);
+        super(message, HttpStatus.NOT_FOUND);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/CaseNotFoundException.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/CaseNotFoundException.java
@@ -1,7 +1,10 @@
 package uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception;
 
-public class CaseNotFoundException extends RuntimeException {
+import org.springframework.http.HttpStatus;
+
+public class CaseNotFoundException extends BaseException {
     public CaseNotFoundException(String message) {
         super(message);
+        this.status = HttpStatus.NOT_FOUND;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/DuplicateCaseException.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/DuplicateCaseException.java
@@ -1,7 +1,10 @@
 package uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception;
 
-public class DuplicateCaseException extends Exception {
+import org.springframework.http.HttpStatus;
+
+public class DuplicateCaseException extends BaseException {
     public DuplicateCaseException(String message) {
         super(message);
+        this.status = HttpStatus.MULTIPLE_CHOICES;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/DuplicateCaseException.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/DuplicateCaseException.java
@@ -4,7 +4,6 @@ import org.springframework.http.HttpStatus;
 
 public class DuplicateCaseException extends BaseException {
     public DuplicateCaseException(String message) {
-        super(message);
-        this.setStatus(HttpStatus.MULTIPLE_CHOICES);
+        super(message, HttpStatus.MULTIPLE_CHOICES);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/DuplicateCaseException.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/DuplicateCaseException.java
@@ -5,6 +5,6 @@ import org.springframework.http.HttpStatus;
 public class DuplicateCaseException extends BaseException {
     public DuplicateCaseException(String message) {
         super(message);
-        this.status = HttpStatus.MULTIPLE_CHOICES;
+        this.setStatus(HttpStatus.MULTIPLE_CHOICES);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/InvalidRequestException.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/InvalidRequestException.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception;
+
+public class InvalidRequestException extends RuntimeException {
+    public InvalidRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/InvalidRequestException.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/InvalidRequestException.java
@@ -5,6 +5,6 @@ import org.springframework.http.HttpStatus;
 public class InvalidRequestException extends BaseException {
     public InvalidRequestException(String message) {
         super(message);
-        this.status = HttpStatus.BAD_REQUEST;
+        this.setStatus(HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/InvalidRequestException.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/InvalidRequestException.java
@@ -1,7 +1,10 @@
 package uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception;
 
-public class InvalidRequestException extends RuntimeException {
+import org.springframework.http.HttpStatus;
+
+public class InvalidRequestException extends BaseException {
     public InvalidRequestException(String message) {
         super(message);
+        this.status = HttpStatus.BAD_REQUEST;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/InvalidRequestException.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/InvalidRequestException.java
@@ -4,7 +4,6 @@ import org.springframework.http.HttpStatus;
 
 public class InvalidRequestException extends BaseException {
     public InvalidRequestException(String message) {
-        super(message);
-        this.setStatus(HttpStatus.BAD_REQUEST);
+        super(message, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/UnauthorizedException.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/UnauthorizedException.java
@@ -4,7 +4,6 @@ import org.springframework.http.HttpStatus;
 
 public class UnauthorizedException extends BaseException {
     public UnauthorizedException(String message) {
-        super(message);
-        this.setStatus(HttpStatus.UNAUTHORIZED);
+        super(message, HttpStatus.UNAUTHORIZED);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/UnauthorizedException.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception;
+
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/UnauthorizedException.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/UnauthorizedException.java
@@ -5,6 +5,6 @@ import org.springframework.http.HttpStatus;
 public class UnauthorizedException extends BaseException {
     public UnauthorizedException(String message) {
         super(message);
-        this.status = HttpStatus.UNAUTHORIZED;
+        this.setStatus(HttpStatus.UNAUTHORIZED);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/UnauthorizedException.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/exception/UnauthorizedException.java
@@ -1,7 +1,10 @@
 package uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception;
 
-public class UnauthorizedException extends RuntimeException {
+import org.springframework.http.HttpStatus;
+
+public class UnauthorizedException extends BaseException {
     public UnauthorizedException(String message) {
         super(message);
+        this.status = HttpStatus.UNAUTHORIZED;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdAccessServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdAccessServiceImpl.java
@@ -12,54 +12,16 @@ import uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception.InvalidReque
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception.UnauthorizedException;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.service.CcdAccessService;
 
-import javax.naming.AuthenticationException;
-
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties.CO_RESP_EMAIL_ADDRESS;
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties.CO_RESP_LETTER_HOLDER_ID_FIELD;
-import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties.CO_RESP_RECEIVED_AOS_FIELD;
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties.RESP_EMAIL_ADDRESS;
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties.RESP_LETTER_HOLDER_ID_FIELD;
-import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties.RESP_RECEIVED_AOS_FIELD;
 
 @Service
 public class CcdAccessServiceImpl extends BaseCcdCaseService implements CcdAccessService {
 
     @Autowired
     private CaseAccessApi caseAccessApi;
-
-    @Override
-    public void linkRespondent(String authorisation, String caseId, String letterHolderId) {
-        UserDetails caseworkerUser = getAnonymousCaseWorkerDetails();
-
-        CaseDetails caseDetails = coreCaseDataApi.readForCaseWorker(
-            caseworkerUser.getAuthToken(),
-            getServiceAuthToken(),
-            caseworkerUser.getId(),
-            jurisdictionId,
-            caseType,
-            caseId
-        );
-
-        if (caseDetails == null) {
-            throw new CaseNotFoundException(String.format("Case with caseId [%s] and letter holder id [%s] not found",
-                caseId, letterHolderId));
-        }
-
-        if (!isValidCaseAndLetterHolder(caseDetails, letterHolderId)) {
-            throw new InvalidRequestException(String.format("Invalid request for caseId [%s] and letter holder id [%s]",
-                caseId, letterHolderId));
-        }
-
-        UserDetails linkingUser = getUserDetails(authorisation);
-
-        if (!isValidUser(caseDetails, linkingUser.getEmail(), letterHolderId)) {
-            throw new UnauthorizedException(String.format("Case with caseId [%s] and letter holder id [%s] "
-                    + "already assigned",
-                caseId, letterHolderId));
-        }
-
-        grantAccessToCase(caseworkerUser, caseId, linkingUser.getId());
-    }
 
     @Override
     public void unlinkRespondent(String authorisation, String caseId) {
@@ -90,47 +52,66 @@ public class CcdAccessServiceImpl extends BaseCcdCaseService implements CcdAcces
         );
     }
 
-    private boolean isValidCaseAndLetterHolder(CaseDetails caseDetails, String letterHolderId) {
-        if (caseDetails == null || caseDetails.getData() == null || StringUtils.isBlank(letterHolderId)) {
+    @Override
+    public void linkRespondent(String authorisation, String caseId, String letterHolderId) {
+        UserDetails caseworkerUser = getAnonymousCaseWorkerDetails();
+
+        CaseDetails caseDetails = coreCaseDataApi.readForCaseWorker(
+            caseworkerUser.getAuthToken(),
+            getServiceAuthToken(),
+            caseworkerUser.getId(),
+            jurisdictionId,
+            caseType,
+            caseId
+        );
+
+        if (caseDetails == null) {
+            throw new CaseNotFoundException(
+                String.format("Case with caseId [%s] and letter holder id [%s] not found",
+                    caseId, letterHolderId));
+        }
+
+        isValidCaseAndLetterHolder(caseDetails, letterHolderId);
+
+        UserDetails linkingUser = getUserDetails(authorisation);
+
+        if (!isValidUser(caseDetails, linkingUser.getEmail(), letterHolderId)) {
+            throw new UnauthorizedException(
+                String.format("Case with caseId [%s] and letter holder id [%s] already assigned or letter holder mismatch",
+                    caseId, letterHolderId));
+        }
+
+        grantAccessToCase(caseworkerUser, caseId, linkingUser.getId());
+    }
+
+    private void isValidCaseAndLetterHolder(CaseDetails caseDetails, String letterHolderId) {
+        if (caseDetails.getData() == null || StringUtils.isBlank(letterHolderId)) {
             throw new InvalidRequestException("Case details or letter holder data are invalid");
         }
-        return true;
     }
 
     private boolean isValidUser(CaseDetails caseDetails, String respondentEmail, String letterHolderId) {
         return isValidRespondentUser(caseDetails, respondentEmail, letterHolderId)
-            || isValidCoRespondentUser(caseDetails, respondentEmail, letterHolderId);
+        || isValidCoRespondentUser(caseDetails, respondentEmail, letterHolderId);
     }
 
     private boolean isValidRespondentUser(CaseDetails caseDetails, String respondentEmail, String letterHolderId) {
         return this.respondentIsValid(caseDetails, letterHolderId)
-            && (caseDetails.getData().get(RESP_EMAIL_ADDRESS) == null
-                || respondentEmail.equalsIgnoreCase((String) caseDetails.getData().get(RESP_EMAIL_ADDRESS))
-            );
+            && caseDetails.getData().get(RESP_EMAIL_ADDRESS) == null
+            || respondentEmail.equalsIgnoreCase((String) caseDetails.getData().get(RESP_EMAIL_ADDRESS));
     }
 
     private boolean isValidCoRespondentUser(CaseDetails caseDetails, String coRespondentEmail, String letterHolderId) {
         return this.coRespondentIsValid(caseDetails, letterHolderId)
-            && (caseDetails.getData().get(CO_RESP_EMAIL_ADDRESS) == null
-                || coRespondentEmail.equalsIgnoreCase((String) caseDetails.getData().get(CO_RESP_EMAIL_ADDRESS))
-            );
+            && caseDetails.getData().get(CO_RESP_EMAIL_ADDRESS) == null
+            || coRespondentEmail.equalsIgnoreCase((String) caseDetails.getData().get(CO_RESP_EMAIL_ADDRESS));
     }
 
     private boolean respondentIsValid(CaseDetails caseDetails, String letterHolderId) {
-        if (letterHolderId.equals(caseDetails.getData().get(RESP_LETTER_HOLDER_ID_FIELD))) {
-            return true;
-        } else {
-            throw new UnauthorizedException(String.format("Respondent letter holder ID [%s] is invalid for case [%s]",
-                letterHolderId, caseDetails.getId()));
-        }
+        return letterHolderId.equals(caseDetails.getData().get(RESP_LETTER_HOLDER_ID_FIELD));
     }
 
     private boolean coRespondentIsValid(CaseDetails caseDetails, String letterHolderId) {
-        if (letterHolderId.equals(caseDetails.getData().get(CO_RESP_LETTER_HOLDER_ID_FIELD))) {
-            return true;
-        } else {
-            throw new UnauthorizedException(String.format("Co-Respondent letter holder ID [%s] is invalid for case [%s]",
-                letterHolderId, caseDetails.getId()));
-        }
+        return letterHolderId.equals(caseDetails.getData().get(CO_RESP_LETTER_HOLDER_ID_FIELD));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdAccessServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdAccessServiceImpl.java
@@ -92,7 +92,7 @@ public class CcdAccessServiceImpl extends BaseCcdCaseService implements CcdAcces
 
     private boolean isValidUser(CaseDetails caseDetails, String respondentEmail, String letterHolderId) {
         return isValidRespondentUser(caseDetails, respondentEmail, letterHolderId)
-        || isValidCoRespondentUser(caseDetails, respondentEmail, letterHolderId);
+            || isValidCoRespondentUser(caseDetails, respondentEmail, letterHolderId);
     }
 
     private boolean isValidRespondentUser(CaseDetails caseDetails, String respondentEmail, String letterHolderId) {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/support/GlobalExceptionHandlerUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/support/GlobalExceptionHandlerUTest.java
@@ -8,6 +8,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception.CaseNotFoundException;
+import uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception.DuplicateCaseException;
+import uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception.InvalidRequestException;
+import uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception.UnauthorizedException;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -40,7 +43,46 @@ public class GlobalExceptionHandlerUTest {
 
         final CaseNotFoundException exception = new CaseNotFoundException(errorMessage);
 
-        ResponseEntity<Object> response = classUnderTest.handleCaseNotFoundException(exception);
+        ResponseEntity<Object> response = classUnderTest.handleApplicationException(exception);
+
+        assertEquals(statusCode, response.getStatusCode());
+        assertEquals(errorMessage, response.getBody());
+    }
+
+    @Test
+    public void whenDuplicateCaseException_thenReturnUnderLyingError() {
+        final HttpStatus statusCode = HttpStatus.MULTIPLE_CHOICES;
+        final String errorMessage = "Error Message";
+
+        final DuplicateCaseException exception = new DuplicateCaseException(errorMessage);
+
+        ResponseEntity<Object> response = classUnderTest.handleApplicationException(exception);
+
+        assertEquals(statusCode, response.getStatusCode());
+        assertEquals(errorMessage, response.getBody());
+    }
+
+    @Test
+    public void whenInvalidRequestException_thenReturnUnderLyingError() {
+        final HttpStatus statusCode = HttpStatus.BAD_REQUEST;
+        final String errorMessage = "Error Message";
+
+        final InvalidRequestException exception = new InvalidRequestException(errorMessage);
+
+        ResponseEntity<Object> response = classUnderTest.handleApplicationException(exception);
+
+        assertEquals(statusCode, response.getStatusCode());
+        assertEquals(errorMessage, response.getBody());
+    }
+
+    @Test
+    public void whenUnauthorizedException_thenReturnUnderLyingError() {
+        final HttpStatus statusCode = HttpStatus.UNAUTHORIZED;
+        final String errorMessage = "Error Message";
+
+        final UnauthorizedException exception = new UnauthorizedException(errorMessage);
+
+        ResponseEntity<Object> response = classUnderTest.handleApplicationException(exception);
 
         assertEquals(statusCode, response.getStatusCode());
         assertEquals(errorMessage, response.getBody());

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/LinkRespondentITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/LinkRespondentITest.java
@@ -26,7 +26,6 @@ import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.UserId;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.CaseMaintenanceServiceApplication;
-import uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CaseState;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties;
 
 import java.util.Collections;
@@ -162,8 +161,7 @@ public class LinkRespondentITest extends AuthIdamMockSupport {
         final String message = getUserDetails();
         final String serviceAuthToken = "serviceAuthToken";
 
-        final CaseDetails caseDetails = CaseDetails.builder()
-            .state(CaseState.AOS_AWAITING.getValue()).data(new HashMap<>()).build();
+        final CaseDetails caseDetails = CaseDetails.builder().data(new HashMap<>()).build();
 
         stubUserDetailsEndpoint(HttpStatus.OK, new EqualToPattern(USER_TOKEN), message);
         stubCaseWorkerAuthentication(HttpStatus.OK);
@@ -184,12 +182,12 @@ public class LinkRespondentITest extends AuthIdamMockSupport {
     }
 
     @Test
-    public void givenLetterHolderIdDoNotMatch_whenLinkRespondent_thenReturnNotFound() throws Exception {
+    public void givenLetterHolderIdDoNotMatch_whenLinkRespondent_thenReturnUnauthorized() throws Exception {
         final String message = getUserDetails();
         final String serviceAuthToken = "serviceAuthToken";
 
         final CaseDetails caseDetails = CaseDetails.builder()
-            .state(CaseState.AOS_AWAITING.getValue())
+            .id(Long.decode(CASE_ID))
             .data(Collections.singletonMap(RESP_LETTER_HOLDER_ID_FIELD, "nonmatchingletterholderid"))
             .build();
 
@@ -212,12 +210,11 @@ public class LinkRespondentITest extends AuthIdamMockSupport {
     }
 
     @Test
-    public void givenLetterHolderIdDoNotMatch_whenLinkCoRespondent_thenReturnNotFound() throws Exception {
+    public void givenLetterHolderIdDoNotMatch_whenLinkCoRespondent_thenReturnUnauthorized() throws Exception {
         final String message = getUserDetails();
         final String serviceAuthToken = "serviceAuthToken";
 
         final CaseDetails caseDetails = CaseDetails.builder()
-            .state(CaseState.AOS_AWAITING.getValue())
             .id(Long.decode(CASE_ID))
             .data(Collections.singletonMap(CO_RESP_LETTER_HOLDER_ID_FIELD, "nonmatchingletterholderid"))
             .build();
@@ -246,7 +243,7 @@ public class LinkRespondentITest extends AuthIdamMockSupport {
         final String serviceAuthToken = "serviceAuthToken";
 
         final CaseDetails caseDetails = CaseDetails.builder()
-            .state(CaseState.AOS_AWAITING.getValue())
+            .id(Long.decode(CASE_ID))
             .data(Collections.singletonMap(RESP_LETTER_HOLDER_ID_FIELD, LETTER_HOLDER_ID))
             .build();
 
@@ -279,7 +276,7 @@ public class LinkRespondentITest extends AuthIdamMockSupport {
         final FeignException feignException = getMockedFeignException(feignStatusCode);
 
         final CaseDetails caseDetails = CaseDetails.builder()
-            .state(CaseState.AOS_AWAITING.getValue())
+            .id(Long.decode(CASE_ID))
             .data(Collections.singletonMap(RESP_LETTER_HOLDER_ID_FIELD, LETTER_HOLDER_ID))
             .build();
 
@@ -319,7 +316,7 @@ public class LinkRespondentITest extends AuthIdamMockSupport {
         final String serviceAuthToken = "serviceAuthToken";
 
         final CaseDetails caseDetails = CaseDetails.builder()
-            .state(CaseState.AOS_AWAITING.getValue())
+            .id(Long.decode(CASE_ID))
             .data(Collections.singletonMap(RESP_LETTER_HOLDER_ID_FIELD, LETTER_HOLDER_ID))
             .build();
 
@@ -359,7 +356,7 @@ public class LinkRespondentITest extends AuthIdamMockSupport {
         final String serviceAuthToken = "serviceAuthToken";
 
         final CaseDetails caseDetails = CaseDetails.builder()
-            .state(CaseState.AOS_AWAITING.getValue())
+            .id(Long.decode(CASE_ID))
             .data(Collections.singletonMap(CO_RESP_LETTER_HOLDER_ID_FIELD, LETTER_HOLDER_ID))
             .build();
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/LinkRespondentServiceImplUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/LinkRespondentServiceImplUTest.java
@@ -120,7 +120,7 @@ public class LinkRespondentServiceImplUTest {
     }
 
     @Test
-    public void givenLetterHolderIdIsNull_whenLinkRespondent_thenThrowCaseNotFoundException() {
+    public void givenLetterHolderIdIsNull_whenLinkRespondent_thenThrowInvalidRequestException() {
         expectedException.expect(InvalidRequestException.class);
         expectedException
             .expectMessage(INVALID_MESSAGE);
@@ -136,7 +136,7 @@ public class LinkRespondentServiceImplUTest {
     }
 
     @Test
-    public void givenLetterHolderIdIsBlank_whenLinkRespondent_thenThrowCaseNotFoundException() {
+    public void givenLetterHolderIdIsBlank_whenLinkRespondent_thenThrowInvalidRequestException() {
         expectedException.expect(InvalidRequestException.class);
         expectedException
             .expectMessage(INVALID_MESSAGE);
@@ -151,7 +151,7 @@ public class LinkRespondentServiceImplUTest {
     }
 
     @Test
-    public void givenLetterHolderIdInCaseIsNull_whenLinkRespondent_thenThrowCaseNotFoundException() {
+    public void givenLetterHolderIdInCaseIsNull_whenLinkRespondent_thenThrowUnauthorizedException() {
         expectedException.expect(UnauthorizedException.class);
         expectedException
             .expectMessage(UNAUTHORIZED_MESSAGE);
@@ -278,8 +278,11 @@ public class LinkRespondentServiceImplUTest {
         );
     }
 
-    @Test(expected = UnauthorizedException.class)
+    @Test
     public void givenRespondentEmailNotMatch_whenLinkCoRespondent_thenThrowUnauthorizedException() {
+        expectedException.expect(UnauthorizedException.class);
+        expectedException
+            .expectMessage(UNAUTHORIZED_MESSAGE);
         CaseDetails caseDetails = CaseDetails.builder()
             .state(CaseState.AOS_AWAITING.getValue())
             .data(ImmutableMap.of(
@@ -303,7 +306,7 @@ public class LinkRespondentServiceImplUTest {
     }
 
     @Test
-    public void givenLetterHolderIdMatches_whenLinkRespondent_thenProceedAsExpected() {
+    public void givenLetterHolderIdMatchesAndEmailNull_whenLinkRespondent_thenGrantUserPermission() {
         CaseDetails caseDetails = CaseDetails.builder()
             .id(Long.decode(CASE_ID))
             .data(Collections.singletonMap(
@@ -326,7 +329,7 @@ public class LinkRespondentServiceImplUTest {
     }
 
     @Test
-    public void givenLetterHolderIdAndEmailMatches_whenLinkRespondent_thenGrantUserPermission() {
+    public void givenLetterHolderIdMatchesAndEmailMatched_whenLinkRespondent_thenGrantUserPermission() {
         CaseDetails caseDetails = CaseDetails.builder()
             .id(Long.decode(CASE_ID))
             .data(ImmutableMap.of(
@@ -350,11 +353,10 @@ public class LinkRespondentServiceImplUTest {
     }
 
     @Test
-    public void givenLetterHolderIdAndEmailMatches_whenLinkCoRespondent_thenGrantUserPermission() {
+    public void givenLetterHolderIdMatchedAndEmailNull_whenLinkCoRespondent_thenGrantUserPermission() {
         CaseDetails caseDetails = CaseDetails.builder()
             .data(ImmutableMap.of(
-                CO_RESP_LETTER_HOLDER_ID_FIELD, LETTER_HOLDER_ID,
-                CO_RESP_EMAIL_ADDRESS, USER_EMAIL
+                CO_RESP_LETTER_HOLDER_ID_FIELD, LETTER_HOLDER_ID
             )).build();
 
         mockCaseDetails(caseDetails);
@@ -373,10 +375,11 @@ public class LinkRespondentServiceImplUTest {
     }
 
     @Test
-    public void givenLetterHolderIMatches_whenLinkCoRespondent_thenProceedAsExpected() {
+    public void givenLetterHolderIdAndEmailMatches_whenLinkCoRespondent_thenGrantUserPermission() {
         CaseDetails caseDetails = CaseDetails.builder()
-            .data(Collections.singletonMap(
-                CO_RESP_LETTER_HOLDER_ID_FIELD, LETTER_HOLDER_ID
+            .data(ImmutableMap.of(
+                CO_RESP_LETTER_HOLDER_ID_FIELD, LETTER_HOLDER_ID,
+                CO_RESP_EMAIL_ADDRESS, USER_EMAIL
             )).build();
 
         mockCaseDetails(caseDetails);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/LinkRespondentServiceImplUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/LinkRespondentServiceImplUTest.java
@@ -18,6 +18,8 @@ import uk.gov.hmcts.reform.ccd.client.model.UserId;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CaseState;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.UserDetails;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception.CaseNotFoundException;
+import uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception.InvalidRequestException;
+import uk.gov.hmcts.reform.divorce.casemaintenanceservice.exception.UnauthorizedException;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.service.UserService;
 
 import java.util.Collections;
@@ -26,32 +28,34 @@ import java.util.Objects;
 import static org.junit.rules.ExpectedException.none;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties.CO_RESP_EMAIL_ADDRESS;
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties.CO_RESP_LETTER_HOLDER_ID_FIELD;
-import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties.CO_RESP_RECEIVED_AOS_FIELD;
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties.RESP_EMAIL_ADDRESS;
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties.RESP_LETTER_HOLDER_ID_FIELD;
-import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties.RESP_RECEIVED_AOS_FIELD;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LinkRespondentServiceImplUTest {
     private static final String JURISDICTION_ID = "DIVORCE";
     private static final String CASE_TYPE = "DIVORCE";
-    private static final String YES_ANSWER = "Yes";
 
     private static final String RESPONDENT_AUTHORISATION = "Bearer RespondentAuthToken";
     private static final String CASEWORKER_AUTHORISATION = "CaseWorkerAuthToken";
-    private static final String CASE_ID = "CaseId";
+    private static final String CASE_ID = "12345678";
     private static final String LETTER_HOLDER_ID = "letterholderId";
     private static final String CASEWORKER_USER_ID = "1";
     private static final String RESPONDENT_USER_ID = "2";
     private static final String USER_EMAIL = "user@email.com";
     private static final String SERVICE_TOKEN = "ServiceToken";
-    private static final String RECEIVED_AOS_FIELD_VALUE = "YES";
+    private static final String RESPONDENT_EMAIL = "aos@respondent.com";
+    private static final String UNAUTHORIZED_MESSAGE =
+        "Case with caseId [12345678] and letter holder id [letterholderId] already assigned or letter holder mismatch";
+    private static final String UNAUTHORIZED_MESSAGE_WRONG_HOLDER_ID =
+        "Case with caseId [12345678] and letter holder id [WrongHolderId] already assigned or letter holder mismatch";
+    private static final String INVALID_MESSAGE = "Case details or letter holder data are invalid";
+    private static final String NOT_FOUND_MESSAGE = "Case with caseId [12345678] and letter holder id [letterholderId] not found";
 
     private static final UserDetails CASE_WORKER_USER = UserDetails.builder()
         .authToken(CASEWORKER_AUTHORISATION)
@@ -96,7 +100,7 @@ public class LinkRespondentServiceImplUTest {
     public void givenNoCaseFound_whenLinkRespondent_thenThrowCaseNotFoundException() {
         expectedException.expect(CaseNotFoundException.class);
         expectedException
-            .expectMessage("Case with caseId [CaseId] and letter holder id [letterholderId] not found");
+            .expectMessage(NOT_FOUND_MESSAGE);
 
         mockCaseDetails(null);
 
@@ -105,9 +109,9 @@ public class LinkRespondentServiceImplUTest {
 
     @Test
     public void givenNoCaseCaseDataFound_whenLinkRespondent_thenThrowCaseNotFoundException() {
-        expectedException.expect(CaseNotFoundException.class);
+        expectedException.expect(InvalidRequestException.class);
         expectedException
-            .expectMessage("Case with caseId [CaseId] and letter holder id [letterholderId] not found");
+            .expectMessage(INVALID_MESSAGE);
         CaseDetails caseDetails = CaseDetails.builder().build();
 
         mockCaseDetails(caseDetails);
@@ -117,9 +121,9 @@ public class LinkRespondentServiceImplUTest {
 
     @Test
     public void givenLetterHolderIdIsNull_whenLinkRespondent_thenThrowCaseNotFoundException() {
-        expectedException.expect(CaseNotFoundException.class);
+        expectedException.expect(InvalidRequestException.class);
         expectedException
-            .expectMessage("Case with caseId [CaseId] and letter holder id [null] not found");
+            .expectMessage(INVALID_MESSAGE);
         CaseDetails caseDetails = CaseDetails.builder()
             .state(CaseState.AOS_AWAITING.getValue())
             .data(Collections.singletonMap(
@@ -133,11 +137,10 @@ public class LinkRespondentServiceImplUTest {
 
     @Test
     public void givenLetterHolderIdIsBlank_whenLinkRespondent_thenThrowCaseNotFoundException() {
-        expectedException.expect(CaseNotFoundException.class);
+        expectedException.expect(InvalidRequestException.class);
         expectedException
-            .expectMessage("Case with caseId [CaseId] and letter holder id [ ] not found");
+            .expectMessage(INVALID_MESSAGE);
         CaseDetails caseDetails = CaseDetails.builder()
-            .state(CaseState.AOS_AWAITING.getValue())
             .data(Collections.singletonMap(
                 RESP_LETTER_HOLDER_ID_FIELD, LETTER_HOLDER_ID
             )).build();
@@ -149,11 +152,10 @@ public class LinkRespondentServiceImplUTest {
 
     @Test
     public void givenLetterHolderIdInCaseIsNull_whenLinkRespondent_thenThrowCaseNotFoundException() {
-        expectedException.expect(CaseNotFoundException.class);
+        expectedException.expect(UnauthorizedException.class);
         expectedException
-            .expectMessage("Case with caseId [CaseId] and letter holder id [letterholderId] not found");
+            .expectMessage(UNAUTHORIZED_MESSAGE);
         CaseDetails caseDetails = CaseDetails.builder()
-            .state(CaseState.AOS_AWAITING.getValue())
             .data(Collections.emptyMap()).build();
 
         mockCaseDetails(caseDetails);
@@ -162,13 +164,14 @@ public class LinkRespondentServiceImplUTest {
     }
 
     @Test
-    public void givenLetterHolderIdsDoNotMatch_whenLinkRespondent_thenThrowCaseNotFoundException() {
-        expectedException.expect(CaseNotFoundException.class);
+    public void givenLetterHolderIdsDoNotMatch_whenLinkRespondent_thenThrowUnauthorizedException() {
+        expectedException.expect(UnauthorizedException.class);
         expectedException
-            .expectMessage("Case with caseId [CaseId] and letter holder id [WrongHolderId] not found");
+            .expectMessage(UNAUTHORIZED_MESSAGE_WRONG_HOLDER_ID);
 
         CaseDetails caseDetails = CaseDetails.builder()
             .state(CaseState.AOS_AWAITING.getValue())
+            .id(Long.decode(CASE_ID))
             .data(Collections.singletonMap(
                 RESP_LETTER_HOLDER_ID_FIELD, LETTER_HOLDER_ID
             )).build();
@@ -180,12 +183,13 @@ public class LinkRespondentServiceImplUTest {
     }
 
     @Test
-    public void givenLetterHolderIdsDoNotMatch_whenLinkCoRespondent_thenThrowCaseNotFoundException() {
-        expectedException.expect(CaseNotFoundException.class);
+    public void givenLetterHolderIdsDoNotMatch_whenLinkCoRespondent_thenThrowUnauthorizedException() {
+        expectedException.expect(UnauthorizedException.class);
         expectedException
-            .expectMessage("Case with caseId [CaseId] and letter holder id [wrongHolderId] not found");
+            .expectMessage(UNAUTHORIZED_MESSAGE_WRONG_HOLDER_ID);
         CaseDetails caseDetails = CaseDetails.builder()
             .state(CaseState.AOS_AWAITING.getValue())
+            .id(Long.decode(CASE_ID))
             .data(Collections.singletonMap(
                 CO_RESP_LETTER_HOLDER_ID_FIELD, LETTER_HOLDER_ID
             )).build();
@@ -193,19 +197,20 @@ public class LinkRespondentServiceImplUTest {
         mockCaseDetails(caseDetails);
 
         classUnderTest.linkRespondent(
-            RESPONDENT_AUTHORISATION, CASE_ID, "wrongHolderId");
+            RESPONDENT_AUTHORISATION, CASE_ID, "WrongHolderId");
     }
 
     @Test
-    public void givenCaseAlreadyLinked_whenLinkRespondent_thenThrowCaseNotFoundException() {
-        expectedException.expect(CaseNotFoundException.class);
+    public void givenCaseAlreadyLinked_whenLinkRespondent_thenThrowUnauthorizedException() {
+        expectedException.expect(UnauthorizedException.class);
         expectedException
-            .expectMessage("Case with caseId [CaseId] and letter holder id [letterholderId] already assigned");
+            .expectMessage(UNAUTHORIZED_MESSAGE);
         CaseDetails caseDetails = CaseDetails.builder()
             .state(CaseState.ISSUED.getValue())
+            .id(Long.decode(CASE_ID))
             .data(ImmutableMap.of(
                 Objects.requireNonNull(RESP_LETTER_HOLDER_ID_FIELD), LETTER_HOLDER_ID,
-                Objects.requireNonNull(RESP_RECEIVED_AOS_FIELD), RECEIVED_AOS_FIELD_VALUE
+                Objects.requireNonNull(RESP_EMAIL_ADDRESS), RESPONDENT_EMAIL
             )).build();
 
         when(coreCaseDataApi.readForCaseWorker(
@@ -221,15 +226,16 @@ public class LinkRespondentServiceImplUTest {
     }
 
     @Test
-    public void givenCaseAlreadyLinked_whenLinkCoRespondent_thenThrowCaseNotFoundException() {
-        expectedException.expect(CaseNotFoundException.class);
+    public void givenCaseAlreadyLinked_whenLinkCoRespondent_thenThrowUnauthorizedException() {
+        expectedException.expect(UnauthorizedException.class);
         expectedException
-            .expectMessage("Case with caseId [CaseId] and letter holder id [letterholderId] already assigned");
+            .expectMessage(UNAUTHORIZED_MESSAGE);
         CaseDetails caseDetails = CaseDetails.builder()
             .state(CaseState.ISSUED.getValue())
+            .id(Long.decode(CASE_ID))
             .data(ImmutableMap.of(
                 Objects.requireNonNull(CO_RESP_LETTER_HOLDER_ID_FIELD), LETTER_HOLDER_ID,
-                Objects.requireNonNull(CO_RESP_RECEIVED_AOS_FIELD), RECEIVED_AOS_FIELD_VALUE
+                Objects.requireNonNull(CO_RESP_EMAIL_ADDRESS), RESPONDENT_EMAIL
             )).build();
 
         when(coreCaseDataApi.readForCaseWorker(
@@ -245,15 +251,14 @@ public class LinkRespondentServiceImplUTest {
     }
 
     @Test
-    public void givenRespondentEmailNotMatch_whenLinkRespondent_thenThrowError() {
-        expectedException.expect(CaseNotFoundException.class);
+    public void givenRespondentEmailNotMatch_whenLinkRespondent_thenThrowUnauthorizedException() {
+        expectedException.expect(UnauthorizedException.class);
         expectedException
-            .expectMessage("Case with caseId [CaseId] and letter holder id [letterholderId] already assigned");
+            .expectMessage(UNAUTHORIZED_MESSAGE);
 
         CaseDetails caseDetails = CaseDetails.builder()
             .state(CaseState.AOS_AWAITING.getValue())
             .data(ImmutableMap.of(
-                RESP_RECEIVED_AOS_FIELD, YES_ANSWER,
                 RESP_LETTER_HOLDER_ID_FIELD, LETTER_HOLDER_ID,
                 RESP_EMAIL_ADDRESS, "RandomEmail@email.com"
             )).build();
@@ -273,12 +278,11 @@ public class LinkRespondentServiceImplUTest {
         );
     }
 
-    @Test(expected = CaseNotFoundException.class)
-    public void givenRespondentEmailNotMatch_whenLinkCoRespondent_thenThrowError() {
+    @Test(expected = UnauthorizedException.class)
+    public void givenRespondentEmailNotMatch_whenLinkCoRespondent_thenThrowUnauthorizedException() {
         CaseDetails caseDetails = CaseDetails.builder()
             .state(CaseState.AOS_AWAITING.getValue())
             .data(ImmutableMap.of(
-                CO_RESP_RECEIVED_AOS_FIELD, YES_ANSWER,
                 CO_RESP_LETTER_HOLDER_ID_FIELD, LETTER_HOLDER_ID,
                 CO_RESP_EMAIL_ADDRESS, "RandomEmail@email.com"
             )).build();
@@ -299,9 +303,9 @@ public class LinkRespondentServiceImplUTest {
     }
 
     @Test
-    public void givenLetterHolderIdAndCaseStateMatches_whenLinkRespondent_thenProceedAsExpected() {
+    public void givenLetterHolderIdMatches_whenLinkRespondent_thenProceedAsExpected() {
         CaseDetails caseDetails = CaseDetails.builder()
-            .state(CaseState.AOS_AWAITING.getValue())
+            .id(Long.decode(CASE_ID))
             .data(Collections.singletonMap(
                 RESP_LETTER_HOLDER_ID_FIELD, LETTER_HOLDER_ID
             )).build();
@@ -321,14 +325,11 @@ public class LinkRespondentServiceImplUTest {
         );
     }
 
-
-
     @Test
     public void givenLetterHolderIdAndEmailMatches_whenLinkRespondent_thenGrantUserPermission() {
         CaseDetails caseDetails = CaseDetails.builder()
-            .state(CaseState.AOS_AWAITING.getValue())
+            .id(Long.decode(CASE_ID))
             .data(ImmutableMap.of(
-                RESP_RECEIVED_AOS_FIELD, YES_ANSWER,
                 RESP_LETTER_HOLDER_ID_FIELD, LETTER_HOLDER_ID,
                 RESP_EMAIL_ADDRESS, USER_EMAIL
             )).build();
@@ -351,9 +352,7 @@ public class LinkRespondentServiceImplUTest {
     @Test
     public void givenLetterHolderIdAndEmailMatches_whenLinkCoRespondent_thenGrantUserPermission() {
         CaseDetails caseDetails = CaseDetails.builder()
-            .state(CaseState.AOS_AWAITING.getValue())
             .data(ImmutableMap.of(
-                CO_RESP_RECEIVED_AOS_FIELD, YES_ANSWER,
                 CO_RESP_LETTER_HOLDER_ID_FIELD, LETTER_HOLDER_ID,
                 CO_RESP_EMAIL_ADDRESS, USER_EMAIL
             )).build();
@@ -374,9 +373,8 @@ public class LinkRespondentServiceImplUTest {
     }
 
     @Test
-    public void givenLetterHolderIdAndCaseStateMatches_whenLinkCoRespondent_thenProceedAsExpected() {
+    public void givenLetterHolderIMatches_whenLinkCoRespondent_thenProceedAsExpected() {
         CaseDetails caseDetails = CaseDetails.builder()
-            .state(CaseState.AOS_AWAITING.getValue())
             .data(Collections.singletonMap(
                 CO_RESP_LETTER_HOLDER_ID_FIELD, LETTER_HOLDER_ID
             )).build();


### PR DESCRIPTION
# Description

[Update linking process to only check respondent email field during linking](https://tools.hmcts.net/jira/browse/DIV-4494)

Parent ticket: [AOS / Co-Resp: use of 'received' and 'answer' fields is wrong.](https://tools.hmcts.net/jira/browse/DIV-4437)

No longer using the AoS Received fields to check if linking of case to respondent(s) is allowed. Now just use email field for respondent(s).

**Note: this also updates the errors being sent to make them more specific to root cause, helping with prod issues along the way.** 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
