### PR TITLE
DIV-4531: Fixing bug for amend petition previous date

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CcdCaseProperties.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CcdCaseProperties.java
@@ -5,10 +5,10 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CcdCaseProperties {
+
     public static final String ISSUE_DATE = "IssueDate";
 
     public static final String D8_CASE_REFERENCE = "D8caseReference";
-    public static final String PREVIOUS_REASONS_DIVORCE = "PreviousReasonsForDivorce";
     public static final String D8_REASON_FOR_DIVORCE = "D8ReasonForDivorce";
     public static final String D8_DIVORCE_WHO = "D8DivorceWho";
     public static final String D8_LEGAL_PROCEEDINGS = "D8LegalProceedings";
@@ -25,4 +25,8 @@ public class CcdCaseProperties {
     public static final String D8_DOCUMENTS_UPLOADED = "D8DocumentsUploaded";
     public static final String D8_REJECT_DOCUMENTS_UPLOADED = "D8RejectDocumentsUploaded";
     public static final String D8_DOCUMENTS_GENERATED = "D8DocumentsGenerated";
+
+    public static final String PREVIOUS_REASONS_DIVORCE = "PreviousReasonsForDivorce";
+    public static final String PREVIOUS_ISSUE_DATE = "PreviousIssueDate";
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/DivorceSessionProperties.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/DivorceSessionProperties.java
@@ -6,7 +6,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class DivorceSessionProperties {
     public static final String PREVIOUS_CASE_ID = "previousCaseId";
-    public static final String PREVIOUS_ISSUE_DATE = "previousIssueDate";
     public static final String PREVIOUS_REASONS_FOR_DIVORCE = "previousReasonsForDivorce";
 
     public static final String LEGAL_PROCEEDINGS = "legalProceedings";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/PetitionServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/PetitionServiceImpl.java
@@ -156,7 +156,7 @@ public class PetitionServiceImpl implements PetitionService,
 
         Object issueDateFromOriginalCase = caseData.get(CcdCaseProperties.ISSUE_DATE);
         if (issueDateFromOriginalCase != null) {
-            caseData.put(DivorceSessionProperties.PREVIOUS_ISSUE_DATE, issueDateFromOriginalCase);
+            caseData.put(CcdCaseProperties.PREVIOUS_ISSUE_DATE, issueDateFromOriginalCase);
         }
 
         // remove all props from old case we do not want in new draft case

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/PetitionServiceImplUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/PetitionServiceImplUTest.java
@@ -11,6 +11,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.client.FormatterServiceClient;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CaseState;
+import uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.DivorceSessionProperties;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.UserDetails;
 import uk.gov.hmcts.reform.divorce.casemaintenanceservice.draftstore.model.Draft;
@@ -288,7 +289,7 @@ public class PetitionServiceImplUTest {
         verify(draftService).createDraft(AUTHORISATION, draftData, true);
         Map<String, Object> ccdCaseDataToBeTransformed = verifyCcdCaseDataToBeTransformed();
         assertThat(ccdCaseDataToBeTransformed, allOf(
-            hasEntry(DivorceSessionProperties.PREVIOUS_ISSUE_DATE, originalCaseIssueDate)
+            hasEntry(CcdCaseProperties.PREVIOUS_ISSUE_DATE, originalCaseIssueDate)
         ));
     }
 
@@ -316,7 +317,7 @@ public class PetitionServiceImplUTest {
         verify(draftService).createDraft(AUTHORISATION, draftData, true);
         Map<String, Object> ccdCaseDataToBeTransformed = verifyCcdCaseDataToBeTransformed();
         assertThat(ccdCaseDataToBeTransformed, allOf(
-            not(hasKey(DivorceSessionProperties.PREVIOUS_ISSUE_DATE))
+            not(hasKey(CcdCaseProperties.PREVIOUS_ISSUE_DATE))
         ));
     }
 


### PR DESCRIPTION
# Description

I was wrongly using the Divorce session attribute name, but actually I should be using the CCD attribute name since the field is inserted before the translation (by CFS).

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
