### PR TITLE
DIV-3956 - reduced logging noise

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/config/HttpConnectionConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/config/HttpConnectionConfiguration.java
@@ -2,8 +2,6 @@ package uk.gov.hmcts.reform.divorce.casemaintenanceservice.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
-import org.apache.http.HttpRequestInterceptor;
-import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -22,7 +20,6 @@ import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.reform.logging.httpcomponents.OutboundRequestIdSettingInterceptor;
-import uk.gov.hmcts.reform.logging.httpcomponents.OutboundRequestLoggingInterceptor;
 
 import static java.util.Arrays.asList;
 
@@ -90,8 +87,6 @@ public class HttpConnectionConfiguration {
             .create()
             .useSystemProperties()
             .addInterceptorFirst(new OutboundRequestIdSettingInterceptor())
-            .addInterceptorFirst((HttpRequestInterceptor) new OutboundRequestLoggingInterceptor())
-            .addInterceptorLast((HttpResponseInterceptor) new OutboundRequestLoggingInterceptor())
             .setDefaultRequestConfig(config)
             .build();
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="WARN">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
# Description

It's causing more than 1 million log messages in production

https://github.com/hmcts/java-logging/blob/master/java-logging-httpcomponents/src/main/java/uk/gov/hmcts/reform/logging/httpcomponents/OutboundRequestLoggingInterceptor.java#L41

Also reduced test loggin to WARN

Before:

![Screenshot 2019-04-05 at 17 06 49](https://user-images.githubusercontent.com/629600/55712665-11a73900-59e7-11e9-8347-c0859dc1ce60.png)

After:

<img width="1422" alt="Screenshot 2019-04-08 at 10 15 48" src="https://user-images.githubusercontent.com/629600/55712809-516e2080-59e7-11e9-9db8-637b7c36d4f1.png">


Fixes #DIV-3956

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
