### PR TITLE
DIV-4871 Prevent petitioner linking to case as respondent

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/ccd/LinkRespondentTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/ccd/LinkRespondentTest.java
@@ -19,7 +19,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties.CO_RESP_LETTER_HOLDER_ID_FIELD;
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties.RESP_EMAIL_ADDRESS;
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties.RESP_LETTER_HOLDER_ID_FIELD;
@@ -51,14 +53,14 @@ public class LinkRespondentTest extends PetitionSupport {
     public void givenJWTTokenIsNull_whenLinkRespondent_thenReturnUnauthorised() {
         Response cmsResponse = linkRespondent(null, "someCaseId", "someLetterHolderId");
 
-        assertEquals(HttpStatus.UNAUTHORIZED.value(), cmsResponse.getStatusCode());
+        assertThat(HttpStatus.UNAUTHORIZED.value(), equalTo(cmsResponse.getStatusCode()));
     }
 
     @Test
     public void givenNoCase_whenLinkRespondent_thenReturnUnauthorised() {
         Response cmsResponse = linkRespondent(getUserToken(), "someCaseId", "someLetterHolderId");
 
-        assertEquals(HttpStatus.UNAUTHORIZED.value(), cmsResponse.getStatusCode());
+        assertThat(HttpStatus.UNAUTHORIZED.value(), equalTo(cmsResponse.getStatusCode()));
     }
 
     @Test
@@ -69,7 +71,7 @@ public class LinkRespondentTest extends PetitionSupport {
 
         Response cmsResponse = linkRespondent(getUserToken(), caseId.toString(), "someLetterHolderId");
 
-        assertEquals(HttpStatus.UNAUTHORIZED.value(), cmsResponse.getStatusCode());
+        assertThat(HttpStatus.UNAUTHORIZED.value(), equalTo(cmsResponse.getStatusCode()));
     }
 
     @SuppressWarnings("unchecked")
@@ -87,7 +89,7 @@ public class LinkRespondentTest extends PetitionSupport {
 
         Response cmsResponse = linkRespondent(getUserToken(), caseId.toString(), "someLetterHolderId");
 
-        assertEquals(HttpStatus.UNAUTHORIZED.value(), cmsResponse.getStatusCode());
+        assertThat(HttpStatus.UNAUTHORIZED.value(), equalTo(cmsResponse.getStatusCode()));
     }
 
     @SuppressWarnings("unchecked")
@@ -110,7 +112,7 @@ public class LinkRespondentTest extends PetitionSupport {
 
         Response cmsResponse = linkRespondent(getUserToken(), caseId.toString(), pinResponse.getUserId());
 
-        assertEquals(HttpStatus.UNAUTHORIZED.value(), cmsResponse.getStatusCode());
+        assertThat(HttpStatus.UNAUTHORIZED.value(), equalTo(cmsResponse.getStatusCode()));
     }
 
     @SuppressWarnings({"unchecked", "Duplicates"})
@@ -133,7 +135,7 @@ public class LinkRespondentTest extends PetitionSupport {
 
         Response cmsResponse = linkRespondent(petitioner.getAuthToken(), caseId.toString(), pinResponse.getUserId());
 
-        assertEquals(HttpStatus.UNAUTHORIZED.value(), cmsResponse.getStatusCode());
+        assertThat(HttpStatus.UNAUTHORIZED.value(), equalTo(cmsResponse.getStatusCode()));
     }
 
     @SuppressWarnings({"unchecked", "Duplicates"})
@@ -159,7 +161,7 @@ public class LinkRespondentTest extends PetitionSupport {
 
         Response cmsResponse = linkRespondent(INVALID_USER_TOKEN, caseId.toString(), pinResponse.getUserId());
 
-        assertEquals(HttpStatus.FORBIDDEN.value(), cmsResponse.getStatusCode());
+        assertThat(HttpStatus.FORBIDDEN.value(), equalTo(cmsResponse.getStatusCode()));
     }
 
     @SuppressWarnings({"unchecked", "Duplicates"})
@@ -193,7 +195,7 @@ public class LinkRespondentTest extends PetitionSupport {
 
         Response response = retrieveCase(upliftedUser.getAuthToken());
 
-        assertEquals(caseId, response.path("id"));
+        assertThat(caseId, equalTo(response.path("id")));
     }
 
     @SuppressWarnings({"unchecked", "Duplicates"})
@@ -221,7 +223,7 @@ public class LinkRespondentTest extends PetitionSupport {
 
         Response response = retrieveCase(upliftedUser.getAuthToken());
 
-        assertEquals(caseId, response.path("id"));
+        assertThat(caseId, equalTo(response.path("id")));
     }
 
     @SuppressWarnings("unchecked")
@@ -251,11 +253,11 @@ public class LinkRespondentTest extends PetitionSupport {
 
         Response response = retrieveCase(upliftedUser.getAuthToken());
 
-        assertEquals(caseId, response.path("id"));
+        assertThat(caseId, equalTo(response.path("id")));
 
         linkResponse = linkRespondent(upliftedUser.getAuthToken(), caseId.toString(), pinResponse.getUserId());
 
-        assertEquals(HttpStatus.OK.value(),linkResponse.getStatusCode());
+        assertThat(HttpStatus.OK.value(),equalTo(linkResponse.getStatusCode()));
     }
 
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/ccd/LinkRespondentTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/ccd/LinkRespondentTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties.CO_RESP_LETTER_HOLDER_ID_FIELD;
+import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties.D8_PETITIONER_EMAIL;
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties.RESP_EMAIL_ADDRESS;
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties.RESP_LETTER_HOLDER_ID_FIELD;
 
@@ -129,6 +130,7 @@ public class LinkRespondentTest extends PetitionSupport {
 
         Map<String, Object> updateCaseData = new HashMap<>();
         updateCaseData.put(RESP_LETTER_HOLDER_ID_FIELD, pinResponse.getUserId());
+        updateCaseData.put(D8_PETITIONER_EMAIL, petitioner.getEmailAddress());
 
         updateCase(updateCaseData, caseId, AWAITING_PAYMENT_NO_STATE_CHANGE_EVENT_ID,
             getCaseWorkerUser().getAuthToken());

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/ccd/LinkRespondentTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/ccd/LinkRespondentTest.java
@@ -79,7 +79,7 @@ public class LinkRespondentTest extends PetitionSupport {
 
         Long caseId = ccdClientSupport.submitCaseForCitizen(caseData, getUserDetails()).getId();
 
-        Map<String, Object> updateCaseData = new HashMap();
+        Map<String, Object> updateCaseData = new HashMap<>();
         updateCaseData.put(RESP_LETTER_HOLDER_ID_FIELD, "nonMatchingLetterHolderId");
 
         updateCase(updateCaseData, caseId, AWAITING_PAYMENT_NO_STATE_CHANGE_EVENT_ID,
@@ -101,7 +101,7 @@ public class LinkRespondentTest extends PetitionSupport {
 
         Long caseId = ccdClientSupport.submitCaseForCitizen(caseData, getUserDetails()).getId();
 
-        Map<String, Object> updateCaseData = new HashMap();
+        Map<String, Object> updateCaseData = new HashMap<>();
         updateCaseData.put(RESP_LETTER_HOLDER_ID_FIELD, pinResponse.getUserId());
         updateCaseData.put(RESP_EMAIL_ADDRESS, RESPONDENT_EMAIL);
 
@@ -113,9 +113,32 @@ public class LinkRespondentTest extends PetitionSupport {
         assertEquals(HttpStatus.UNAUTHORIZED.value(), cmsResponse.getStatusCode());
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "Duplicates"})
     @Test
-    public void givenInvalidUserToken_whenLinkRespondent_thenReturnForbidden() throws Exception {
+    public void givenPetitionerAttemptsLinking_whenLinkRespondent_thenReturnUnauthorized() {
+        final String respondentFirstName = "respondent-" + UUID.randomUUID().toString();
+
+        final PinResponse pinResponse = idamTestSupport.createPinUser(respondentFirstName);
+
+        Map<String, Object> caseData = ResourceLoader.loadJsonToObject(PAYLOAD_CONTEXT_PATH + "linked-case.json", Map.class);
+
+        UserDetails petitioner = getUserDetails();
+        Long caseId = ccdClientSupport.submitCaseForCitizen(caseData, petitioner).getId();
+
+        Map<String, Object> updateCaseData = new HashMap<>();
+        updateCaseData.put(RESP_LETTER_HOLDER_ID_FIELD, pinResponse.getUserId());
+
+        updateCase(updateCaseData, caseId, AWAITING_PAYMENT_NO_STATE_CHANGE_EVENT_ID,
+            getCaseWorkerUser().getAuthToken());
+
+        Response cmsResponse = linkRespondent(petitioner.getAuthToken(), caseId.toString(), pinResponse.getUserId());
+
+        assertEquals(HttpStatus.UNAUTHORIZED.value(), cmsResponse.getStatusCode());
+    }
+
+    @SuppressWarnings({"unchecked", "Duplicates"})
+    @Test
+    public void givenInvalidUserToken_whenLinkRespondent_thenReturnForbidden() {
         final String respondentFirstName = "respondent-" + UUID.randomUUID().toString();
 
         final PinResponse pinResponse = idamTestSupport.createPinUser(respondentFirstName);
@@ -126,7 +149,7 @@ public class LinkRespondentTest extends PetitionSupport {
 
         Long caseId = ccdClientSupport.submitCaseForCitizen(caseData, petitionerUser).getId();
 
-        Map<String, Object> updateCaseData = new HashMap();
+        Map<String, Object> updateCaseData = new HashMap<>();
         updateCaseData.put(RESP_LETTER_HOLDER_ID_FIELD, pinResponse.getUserId());
 
         updateCase(updateCaseData, caseId, AWAITING_PAYMENT_NO_STATE_CHANGE_EVENT_ID,
@@ -139,10 +162,9 @@ public class LinkRespondentTest extends PetitionSupport {
         assertEquals(HttpStatus.FORBIDDEN.value(), cmsResponse.getStatusCode());
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "Duplicates"})
     @Test
-    public void givenLetterHolderIdMatches_whenLinkRespondent_thenGrantAccessToCase()
-        throws Exception {
+    public void givenLetterHolderIdMatches_whenLinkRespondent_thenGrantAccessToCase() {
 
         final String respondentFirstName = "respondent-" + UUID.randomUUID().toString();
 
@@ -155,7 +177,7 @@ public class LinkRespondentTest extends PetitionSupport {
 
         Long caseId = ccdClientSupport.submitCaseForCitizen(caseData, petitionerUser).getId();
 
-        Map<String, Object> updateCaseData = new HashMap();
+        Map<String, Object> updateCaseData = new HashMap<>();
         updateCaseData.put(RESP_LETTER_HOLDER_ID_FIELD, pinResponse.getUserId());
 
         updateCase(updateCaseData, caseId, AWAITING_PAYMENT_NO_STATE_CHANGE_EVENT_ID,
@@ -174,11 +196,9 @@ public class LinkRespondentTest extends PetitionSupport {
         assertEquals(caseId, response.path("id"));
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "Duplicates"})
     @Test
-    public void givenLetterHolderIdMatches_whenLinkCoRespondent_thenGrantAccessToCase()
-        throws Exception {
-
+    public void givenLetterHolderIdMatches_whenLinkCoRespondent_thenGrantAccessToCase() {
         final String respondentFirstName = "respondent-" + UUID.randomUUID().toString();
 
         final PinResponse pinResponse = idamTestSupport.createPinUser(respondentFirstName);
@@ -204,9 +224,9 @@ public class LinkRespondentTest extends PetitionSupport {
         assertEquals(caseId, response.path("id"));
     }
 
+    @SuppressWarnings("unchecked")
     @Test
-    public void givenLinkedCoRespondent_whenReLinkingCoRespondent_thenProcessAsNormal()
-        throws Exception {
+    public void givenLinkedCoRespondent_whenReLinkingCoRespondent_thenProcessAsNormal() {
 
         final String respondentFirstName = "respondent-" + UUID.randomUUID().toString();
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
@@ -38,13 +38,13 @@ public abstract class IntegrationTest {
     }
 
     @PostConstruct
-    public void init(){
+    public void init() {
         if (!Strings.isNullOrEmpty(httpProxy)) {
             try {
                 URL proxy = new URL(httpProxy);
                 // check proxy connectivity
-                if(!InetAddress.getByName(proxy.getHost()).isReachable(2000)) {
-                    throw new RuntimeException("Proxy server is unreachable");
+                if (!InetAddress.getByName(proxy.getHost()).isReachable(2000)) {
+                    throw new IOException();
                 }
                 System.setProperty("http.proxyHost", proxy.getHost());
                 System.setProperty("http.proxyPort", Integer.toString(proxy.getPort()));

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CcdCaseProperties.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CcdCaseProperties.java
@@ -16,11 +16,9 @@ public class CcdCaseProperties {
     public static final String D8_SCREEN_HAS_MARRIAGE_BROKEN = "D8ScreenHasMarriageBroken";
     public static final String D8_DIVORCE_UNIT = "D8DivorceUnit";
     public static final String CO_RESP_LETTER_HOLDER_ID_FIELD = "CoRespLetterHolderId";
-    public static final String CO_RESP_RECEIVED_AOS_FIELD = "ReceivedAosFromCoResp";
     public static final String CO_RESP_EMAIL_ADDRESS = "CoRespEmailAddress";
 
     public static final String RESP_LETTER_HOLDER_ID_FIELD = "AosLetterHolderId";
-    public static final String RESP_RECEIVED_AOS_FIELD = "ReceivedAOSfromResp";
     public static final String RESP_EMAIL_ADDRESS = "RespEmailAddress";
 
     public static final String D8_DOCUMENTS_UPLOADED = "D8DocumentsUploaded";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdAccessServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdAccessServiceImpl.java
@@ -88,7 +88,8 @@ public class CcdAccessServiceImpl extends BaseCcdCaseService implements CcdAcces
 
         if (!isValidRespondent(caseDetails, linkingUser.getEmail(), respondentType)) {
             throw new UnauthorizedException(format("Case with caseId [%s] and letter holder id [%s] already assigned for [%s] "
-                + "or Petitioner attempted to link case as respondent. Check previous logs for more information.", caseId, letterHolderId, respondentType));
+                + "or Petitioner attempted to link case as respondent. Check previous logs for more information.",
+                caseId, letterHolderId, respondentType));
         }
 
         grantAccessToCase(caseworkerUser, caseId, linkingUser.getId());

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdAccessServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdAccessServiceImpl.java
@@ -88,8 +88,8 @@ public class CcdAccessServiceImpl extends BaseCcdCaseService implements CcdAcces
 
         if (!isValidRespondent(caseDetails, linkingUser.getEmail(), respondentType)) {
             throw new UnauthorizedException(format("Case with caseId [%s] and letter holder id [%s] already assigned for [%s] "
-                + "or Petitioner attempted to link case as respondent. Check previous logs for more information.",
-                caseId, letterHolderId, respondentType));
+                + "or Petitioner attempted to link case as [%s]. Check previous logs for more information.",
+                caseId, letterHolderId, respondentType, respondentType));
         }
 
         grantAccessToCase(caseworkerUser, caseId, linkingUser.getId());

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdAccessServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdAccessServiceImpl.java
@@ -88,8 +88,8 @@ public class CcdAccessServiceImpl extends BaseCcdCaseService implements CcdAcces
 
         if (!isValidRespondent(caseDetails, linkingUser.getEmail(), respondentType)) {
             throw new UnauthorizedException(format("Case with caseId [%s] and letter holder id [%s] already assigned for [%s] "
-                + "or Petitioner attempted to link case as [%s]. Check previous logs for more information.",
-                caseId, letterHolderId, respondentType, respondentType));
+                + "or Petitioner attempted to link case. Check previous logs for more information.",
+                caseId, letterHolderId, respondentType));
         }
 
         grantAccessToCase(caseworkerUser, caseId, linkingUser.getId());

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/LinkRespondentServiceImplUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/LinkRespondentServiceImplUTest.java
@@ -55,10 +55,10 @@ public class LinkRespondentServiceImplUTest {
     private static final String RESPONDENT_EMAIL = "aos@respondent.com";
     private static final String RESP_UNAUTHORIZED_MESSAGE =
         "Case with caseId [12345678] and letter holder id [letterholderId] already assigned for [RESPONDENT] "
-            + "or Petitioner attempted to link case as respondent. Check previous logs for more information.";
+            + "or Petitioner attempted to link case as [RESPONDENT]. Check previous logs for more information.";
     private static final String CO_RESP_UNAUTHORIZED_MESSAGE =
         "Case with caseId [12345678] and letter holder id [letterholderId] already assigned for [CO_RESPONDENT] "
-            + "or Petitioner attempted to link case as respondent. Check previous logs for more information.";
+            + "or Petitioner attempted to link case as [CO_RESPONDENT]. Check previous logs for more information.";
     private static final String UNAUTHORIZED_MESSAGE_WRONG_HOLDER_ID =
         "Case with caseId [12345678] and letter holder id [WrongHolderId] mismatch.";
     private static final String INVALID_MESSAGE = "Case details or letter holder data are invalid";
@@ -241,6 +241,31 @@ public class LinkRespondentServiceImplUTest {
             .id(Long.decode(CASE_ID))
             .data(ImmutableMap.of(
                 Objects.requireNonNull(RESP_LETTER_HOLDER_ID_FIELD), LETTER_HOLDER_ID,
+                Objects.requireNonNull(D8_PETITIONER_EMAIL), USER_EMAIL
+            )).build();
+
+        when(coreCaseDataApi.readForCaseWorker(
+            CASEWORKER_AUTHORISATION,
+            SERVICE_TOKEN,
+            CASEWORKER_USER_ID,
+            JURISDICTION_ID,
+            CASE_TYPE,
+            CASE_ID
+        )).thenReturn(caseDetails);
+        when(userService.retrieveUserDetails(PET_AUTHORISATION)).thenReturn(PETITIONER_USER);
+
+        classUnderTest.linkRespondent(PET_AUTHORISATION, CASE_ID, LETTER_HOLDER_ID);
+    }
+
+    @Test
+    public void givenUserIsPetitioner_whenLinkCoRespondent_thenThrowUnauthorizedException() {
+        expectedException.expect(UnauthorizedException.class);
+        expectedException.expectMessage(CO_RESP_UNAUTHORIZED_MESSAGE);
+        CaseDetails caseDetails = CaseDetails.builder()
+            .state(CaseState.ISSUED.getValue())
+            .id(Long.decode(CASE_ID))
+            .data(ImmutableMap.of(
+                Objects.requireNonNull(CO_RESP_LETTER_HOLDER_ID_FIELD), LETTER_HOLDER_ID,
                 Objects.requireNonNull(D8_PETITIONER_EMAIL), USER_EMAIL
             )).build();
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/LinkRespondentServiceImplUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/LinkRespondentServiceImplUTest.java
@@ -55,10 +55,10 @@ public class LinkRespondentServiceImplUTest {
     private static final String RESPONDENT_EMAIL = "aos@respondent.com";
     private static final String RESP_UNAUTHORIZED_MESSAGE =
         "Case with caseId [12345678] and letter holder id [letterholderId] already assigned for [RESPONDENT] "
-            + "or Petitioner attempted to link case as [RESPONDENT]. Check previous logs for more information.";
+            + "or Petitioner attempted to link case. Check previous logs for more information.";
     private static final String CO_RESP_UNAUTHORIZED_MESSAGE =
         "Case with caseId [12345678] and letter holder id [letterholderId] already assigned for [CO_RESPONDENT] "
-            + "or Petitioner attempted to link case as [CO_RESPONDENT]. Check previous logs for more information.";
+            + "or Petitioner attempted to link case. Check previous logs for more information.";
     private static final String UNAUTHORIZED_MESSAGE_WRONG_HOLDER_ID =
         "Case with caseId [12345678] and letter holder id [WrongHolderId] mismatch.";
     private static final String INVALID_MESSAGE = "Case details or letter holder data are invalid";

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/LinkRespondentServiceImplUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/LinkRespondentServiceImplUTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties.CO_RESP_EMAIL_ADDRESS;
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties.CO_RESP_LETTER_HOLDER_ID_FIELD;
+import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties.D8_PETITIONER_EMAIL;
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties.RESP_EMAIL_ADDRESS;
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.domain.model.CcdCaseProperties.RESP_LETTER_HOLDER_ID_FIELD;
 
@@ -42,20 +43,22 @@ public class LinkRespondentServiceImplUTest {
     private static final String CASE_TYPE = "DIVORCE";
 
     private static final String RESPONDENT_AUTHORISATION = "Bearer RespondentAuthToken";
+    private static final String PET_AUTHORISATION = "Bearer PetAuthToken";
     private static final String CASEWORKER_AUTHORISATION = "CaseWorkerAuthToken";
     private static final String CASE_ID = "12345678";
     private static final String LETTER_HOLDER_ID = "letterholderId";
     private static final String CASEWORKER_USER_ID = "1";
     private static final String RESPONDENT_USER_ID = "2";
+    private static final String PET_USER_ID = "3";
     private static final String USER_EMAIL = "user@email.com";
     private static final String SERVICE_TOKEN = "ServiceToken";
     private static final String RESPONDENT_EMAIL = "aos@respondent.com";
     private static final String RESP_UNAUTHORIZED_MESSAGE =
         "Case with caseId [12345678] and letter holder id [letterholderId] already assigned for [RESPONDENT] "
-            + "Check previous logs for more information.";
+            + "or Petitioner attempted to link case as respondent. Check previous logs for more information.";
     private static final String CO_RESP_UNAUTHORIZED_MESSAGE =
         "Case with caseId [12345678] and letter holder id [letterholderId] already assigned for [CO_RESPONDENT] "
-            + "Check previous logs for more information.";
+            + "or Petitioner attempted to link case as respondent. Check previous logs for more information.";
     private static final String UNAUTHORIZED_MESSAGE_WRONG_HOLDER_ID =
         "Case with caseId [12345678] and letter holder id [WrongHolderId] mismatch.";
     private static final String INVALID_MESSAGE = "Case details or letter holder data are invalid";
@@ -69,6 +72,12 @@ public class LinkRespondentServiceImplUTest {
     private static final UserDetails RESPONDENT_USER = UserDetails.builder()
         .authToken(RESPONDENT_AUTHORISATION)
         .id(RESPONDENT_USER_ID)
+        .email(USER_EMAIL)
+        .build();
+
+    private static final UserDetails PETITIONER_USER = UserDetails.builder()
+        .authToken(PET_AUTHORISATION)
+        .id(PET_USER_ID)
         .email(USER_EMAIL)
         .build();
 
@@ -95,7 +104,6 @@ public class LinkRespondentServiceImplUTest {
         ReflectionTestUtils.setField(classUnderTest, "jurisdictionId", JURISDICTION_ID);
         ReflectionTestUtils.setField(classUnderTest, "caseType", CASE_TYPE);
 
-        when(userService.retrieveUserDetails(RESPONDENT_AUTHORISATION)).thenReturn(RESPONDENT_USER);
         when(userService.retrieveAnonymousCaseWorkerDetails()).thenReturn(CASE_WORKER_USER);
         when(authTokenGenerator.generate()).thenReturn(SERVICE_TOKEN);
     }
@@ -112,7 +120,7 @@ public class LinkRespondentServiceImplUTest {
     }
 
     @Test
-    public void givenNoCaseCaseDataFound_whenLinkRespondent_thenThrowCaseNotFoundException() {
+    public void givenNoCaseDataFound_whenLinkRespondent_thenThrowCaseNotFoundException() {
         expectedException.expect(InvalidRequestException.class);
         expectedException.expectMessage(INVALID_MESSAGE);
         CaseDetails caseDetails = CaseDetails.builder().build();
@@ -219,8 +227,34 @@ public class LinkRespondentServiceImplUTest {
             CASE_TYPE,
             CASE_ID
         )).thenReturn(caseDetails);
+        when(userService.retrieveUserDetails(RESPONDENT_AUTHORISATION)).thenReturn(RESPONDENT_USER);
 
         classUnderTest.linkRespondent(RESPONDENT_AUTHORISATION, CASE_ID, LETTER_HOLDER_ID);
+    }
+
+    @Test
+    public void givenUserIsPetitioner_whenLinkRespondent_thenThrowUnauthorizedException() {
+        expectedException.expect(UnauthorizedException.class);
+        expectedException.expectMessage(RESP_UNAUTHORIZED_MESSAGE);
+        CaseDetails caseDetails = CaseDetails.builder()
+            .state(CaseState.ISSUED.getValue())
+            .id(Long.decode(CASE_ID))
+            .data(ImmutableMap.of(
+                Objects.requireNonNull(RESP_LETTER_HOLDER_ID_FIELD), LETTER_HOLDER_ID,
+                Objects.requireNonNull(D8_PETITIONER_EMAIL), USER_EMAIL
+            )).build();
+
+        when(coreCaseDataApi.readForCaseWorker(
+            CASEWORKER_AUTHORISATION,
+            SERVICE_TOKEN,
+            CASEWORKER_USER_ID,
+            JURISDICTION_ID,
+            CASE_TYPE,
+            CASE_ID
+        )).thenReturn(caseDetails);
+        when(userService.retrieveUserDetails(PET_AUTHORISATION)).thenReturn(PETITIONER_USER);
+
+        classUnderTest.linkRespondent(PET_AUTHORISATION, CASE_ID, LETTER_HOLDER_ID);
     }
 
     @Test
@@ -243,6 +277,7 @@ public class LinkRespondentServiceImplUTest {
             CASE_TYPE,
             CASE_ID
         )).thenReturn(caseDetails);
+        when(userService.retrieveUserDetails(RESPONDENT_AUTHORISATION)).thenReturn(RESPONDENT_USER);
 
         classUnderTest.linkRespondent(RESPONDENT_AUTHORISATION, CASE_ID, LETTER_HOLDER_ID);
     }
@@ -261,6 +296,7 @@ public class LinkRespondentServiceImplUTest {
             )).build();
 
         mockCaseDetails(caseDetails);
+        when(userService.retrieveUserDetails(RESPONDENT_AUTHORISATION)).thenReturn(RESPONDENT_USER);
 
         classUnderTest.linkRespondent(RESPONDENT_AUTHORISATION, CASE_ID, LETTER_HOLDER_ID);
 
@@ -288,6 +324,7 @@ public class LinkRespondentServiceImplUTest {
             )).build();
 
         mockCaseDetails(caseDetails);
+        when(userService.retrieveUserDetails(RESPONDENT_AUTHORISATION)).thenReturn(RESPONDENT_USER);
 
         classUnderTest.linkRespondent(RESPONDENT_AUTHORISATION, CASE_ID, LETTER_HOLDER_ID);
 
@@ -311,6 +348,7 @@ public class LinkRespondentServiceImplUTest {
             )).build();
 
         mockCaseDetails(caseDetails);
+        when(userService.retrieveUserDetails(RESPONDENT_AUTHORISATION)).thenReturn(RESPONDENT_USER);
 
         classUnderTest.linkRespondent(RESPONDENT_AUTHORISATION, CASE_ID, LETTER_HOLDER_ID);
 
@@ -335,6 +373,7 @@ public class LinkRespondentServiceImplUTest {
             )).build();
 
         mockCaseDetails(caseDetails);
+        when(userService.retrieveUserDetails(RESPONDENT_AUTHORISATION)).thenReturn(RESPONDENT_USER);
 
         classUnderTest.linkRespondent(RESPONDENT_AUTHORISATION, CASE_ID, LETTER_HOLDER_ID);
 
@@ -358,6 +397,7 @@ public class LinkRespondentServiceImplUTest {
             )).build();
 
         mockCaseDetails(caseDetails);
+        when(userService.retrieveUserDetails(RESPONDENT_AUTHORISATION)).thenReturn(RESPONDENT_USER);
 
         classUnderTest.linkRespondent(RESPONDENT_AUTHORISATION, CASE_ID, LETTER_HOLDER_ID);
 
@@ -382,6 +422,7 @@ public class LinkRespondentServiceImplUTest {
             )).build();
 
         mockCaseDetails(caseDetails);
+        when(userService.retrieveUserDetails(RESPONDENT_AUTHORISATION)).thenReturn(RESPONDENT_USER);
 
         classUnderTest.linkRespondent(RESPONDENT_AUTHORISATION, CASE_ID, LETTER_HOLDER_ID);
 
@@ -398,6 +439,7 @@ public class LinkRespondentServiceImplUTest {
 
     @Test
     public void givenUserWithCase_whenUnlinkUser_thenCallRemovePermissionAPI() {
+        when(userService.retrieveUserDetails(RESPONDENT_AUTHORISATION)).thenReturn(RESPONDENT_USER);
         classUnderTest.unlinkRespondent(RESPONDENT_AUTHORISATION, CASE_ID);
 
         verify(caseAccessApi).revokeAccessToCase(

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/LinkRespondentServiceImplUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/LinkRespondentServiceImplUTest.java
@@ -106,6 +106,7 @@ public class LinkRespondentServiceImplUTest {
 
         when(userService.retrieveAnonymousCaseWorkerDetails()).thenReturn(CASE_WORKER_USER);
         when(authTokenGenerator.generate()).thenReturn(SERVICE_TOKEN);
+        when(userService.retrieveUserDetails(RESPONDENT_AUTHORISATION)).thenReturn(RESPONDENT_USER);
     }
 
     @Test
@@ -227,7 +228,6 @@ public class LinkRespondentServiceImplUTest {
             CASE_TYPE,
             CASE_ID
         )).thenReturn(caseDetails);
-        when(userService.retrieveUserDetails(RESPONDENT_AUTHORISATION)).thenReturn(RESPONDENT_USER);
 
         classUnderTest.linkRespondent(RESPONDENT_AUTHORISATION, CASE_ID, LETTER_HOLDER_ID);
     }
@@ -277,7 +277,6 @@ public class LinkRespondentServiceImplUTest {
             CASE_TYPE,
             CASE_ID
         )).thenReturn(caseDetails);
-        when(userService.retrieveUserDetails(RESPONDENT_AUTHORISATION)).thenReturn(RESPONDENT_USER);
 
         classUnderTest.linkRespondent(RESPONDENT_AUTHORISATION, CASE_ID, LETTER_HOLDER_ID);
     }
@@ -296,7 +295,6 @@ public class LinkRespondentServiceImplUTest {
             )).build();
 
         mockCaseDetails(caseDetails);
-        when(userService.retrieveUserDetails(RESPONDENT_AUTHORISATION)).thenReturn(RESPONDENT_USER);
 
         classUnderTest.linkRespondent(RESPONDENT_AUTHORISATION, CASE_ID, LETTER_HOLDER_ID);
 
@@ -324,7 +322,6 @@ public class LinkRespondentServiceImplUTest {
             )).build();
 
         mockCaseDetails(caseDetails);
-        when(userService.retrieveUserDetails(RESPONDENT_AUTHORISATION)).thenReturn(RESPONDENT_USER);
 
         classUnderTest.linkRespondent(RESPONDENT_AUTHORISATION, CASE_ID, LETTER_HOLDER_ID);
 
@@ -348,7 +345,6 @@ public class LinkRespondentServiceImplUTest {
             )).build();
 
         mockCaseDetails(caseDetails);
-        when(userService.retrieveUserDetails(RESPONDENT_AUTHORISATION)).thenReturn(RESPONDENT_USER);
 
         classUnderTest.linkRespondent(RESPONDENT_AUTHORISATION, CASE_ID, LETTER_HOLDER_ID);
 
@@ -373,7 +369,6 @@ public class LinkRespondentServiceImplUTest {
             )).build();
 
         mockCaseDetails(caseDetails);
-        when(userService.retrieveUserDetails(RESPONDENT_AUTHORISATION)).thenReturn(RESPONDENT_USER);
 
         classUnderTest.linkRespondent(RESPONDENT_AUTHORISATION, CASE_ID, LETTER_HOLDER_ID);
 
@@ -397,7 +392,6 @@ public class LinkRespondentServiceImplUTest {
             )).build();
 
         mockCaseDetails(caseDetails);
-        when(userService.retrieveUserDetails(RESPONDENT_AUTHORISATION)).thenReturn(RESPONDENT_USER);
 
         classUnderTest.linkRespondent(RESPONDENT_AUTHORISATION, CASE_ID, LETTER_HOLDER_ID);
 
@@ -422,7 +416,6 @@ public class LinkRespondentServiceImplUTest {
             )).build();
 
         mockCaseDetails(caseDetails);
-        when(userService.retrieveUserDetails(RESPONDENT_AUTHORISATION)).thenReturn(RESPONDENT_USER);
 
         classUnderTest.linkRespondent(RESPONDENT_AUTHORISATION, CASE_ID, LETTER_HOLDER_ID);
 


### PR DESCRIPTION
[Prevent petitioner from linking as respondent](https://tools.hmcts.net/jira/browse/DIV-4871)

Bug-fix to prevent the petitioner linking as respondent, found in production issue. 