### PR TITLE
Override Spring's management endpoint cache to 30 seconds in AAT/Preview

### DIFF
--- a/charts/div-cms/values.aat.template.yaml
+++ b/charts/div-cms/values.aat.template.yaml
@@ -10,7 +10,7 @@ java:
         IDAM_API_REDIRECT_URL : "https://div-pfe-aat.service.core-compute-aat.internal/authenticated"
         CASE_DATA_STORE_BASEURL : "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
         APPINSIGHTS_INSTRUMENTATIONKEY : "63c30ef9-a27b-4d38-8afc-4c180fb6ac33"
-        MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE: "30000"
+        MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
 
     # Don't modify below here
     image: ${IMAGE_NAME}

--- a/charts/div-cms/values.aat.template.yaml
+++ b/charts/div-cms/values.aat.template.yaml
@@ -10,6 +10,7 @@ java:
         IDAM_API_REDIRECT_URL : "https://div-pfe-aat.service.core-compute-aat.internal/authenticated"
         CASE_DATA_STORE_BASEURL : "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
         APPINSIGHTS_INSTRUMENTATIONKEY : "63c30ef9-a27b-4d38-8afc-4c180fb6ac33"
+        MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE: "30000"
 
     # Don't modify below here
     image: ${IMAGE_NAME}

--- a/charts/div-cms/values.preview.template.yaml
+++ b/charts/div-cms/values.preview.template.yaml
@@ -10,7 +10,7 @@ java:
         IDAM_API_REDIRECT_URL : "https://div-pfe-aat.service.core-compute-aat.internal/authenticated"
         CASE_DATA_STORE_BASEURL : "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
         APPINSIGHTS_INSTRUMENTATIONKEY : "63c30ef9-a27b-4d38-8afc-4c180fb6ac33"
-        MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE: "30000"
+        MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
 
     # Don't modify below here
     image: ${IMAGE_NAME}

--- a/charts/div-cms/values.preview.template.yaml
+++ b/charts/div-cms/values.preview.template.yaml
@@ -10,6 +10,7 @@ java:
         IDAM_API_REDIRECT_URL : "https://div-pfe-aat.service.core-compute-aat.internal/authenticated"
         CASE_DATA_STORE_BASEURL : "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
         APPINSIGHTS_INSTRUMENTATIONKEY : "63c30ef9-a27b-4d38-8afc-4c180fb6ac33"
+        MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE: "30000"
 
     # Don't modify below here
     image: ${IMAGE_NAME}

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -2,3 +2,4 @@ vault_env = "preprod"
 idam_api_baseurl = "https://idam-api.aat.platform.hmcts.net"
 
 capacity = "2"
+health_check_ttl = 30000

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -50,6 +50,7 @@ module "div-cms" {
         IDAM_CASEWORKER_USERNAME                              = "${data.azurerm_key_vault_secret.idam-caseworker-username.value}"
         IDAM_CASEWORKER_PASSWORD                              = "${data.azurerm_key_vault_secret.idam-caseworker-password.value}"
         IDAM_API_REDIRECT_URL                                 = "${local.petitioner_fe_baseurl}/authenticated"
+        MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE                = "${var.health_check_ttl}"
     }
 }
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -50,7 +50,7 @@ module "div-cms" {
         IDAM_CASEWORKER_USERNAME                              = "${data.azurerm_key_vault_secret.idam-caseworker-username.value}"
         IDAM_CASEWORKER_PASSWORD                              = "${data.azurerm_key_vault_secret.idam-caseworker-password.value}"
         IDAM_API_REDIRECT_URL                                 = "${local.petitioner_fe_baseurl}/authenticated"
-        MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE                = "${var.health_check_ttl}"
+        MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE                = "${var.health_check_ttl}"
     }
 }
 

--- a/infrastructure/preview.tfvars
+++ b/infrastructure/preview.tfvars
@@ -1,2 +1,3 @@
 vault_env = "preprod"
 idam_api_baseurl = "https://idam-api.aat.platform.hmcts.net"
+health_check_ttl = 30000

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -60,3 +60,8 @@ variable "vault_env" {}
 variable "common_tags" {
     type = "map"
 }
+
+variable "health_check_ttl" {
+    type = "string"
+    value = "4000"
+}


### PR DESCRIPTION
# Description

To prevent hammering AAT, as every `/health` call checks _every_ dependent service, generating sometimes ~30 subsequent calls (e.g COS)

Tested locally via
`MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE=60000 ./gradlew clean bootrun`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
