### PR TITLE
Fix test bulk case hearing date

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/ccd/CcdBulkCaseUpdateTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/ccd/CcdBulkCaseUpdateTest.java
@@ -6,11 +6,16 @@ import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.divorce.model.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.PetitionSupport;
 
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
 
 public class CcdBulkCaseUpdateTest extends PetitionSupport {
 
     private static final String CASE_PAYLOAD_PATH = "bulk-case.json";
+    private static final String COURT_HEARING_DATETIME = "hearingDate";
 
     @Test
     public void shouldUpdateBulkCase() {
@@ -18,7 +23,10 @@ public class CcdBulkCaseUpdateTest extends PetitionSupport {
 
         Long caseId = submitBulkCase(CASE_PAYLOAD_PATH, caseWorkerUser).getBody().path("id");
 
-        Response cmsResponse = updateBulkCase(CASE_PAYLOAD_PATH,
+        // Hearing Date is a mandatory field that must be set in the future
+        Map<String, Object> updateData = Collections.singletonMap(COURT_HEARING_DATETIME, LocalDateTime.now().plusMonths(3));
+
+        Response cmsResponse = updateBulkCase(updateData,
             caseId,
             BULK_CASE_SCHEDULE_EVENT_ID,
             caseWorkerUser.getAuthToken());

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/ccd/CcdBulkCaseUpdateTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/ccd/CcdBulkCaseUpdateTest.java
@@ -24,7 +24,7 @@ public class CcdBulkCaseUpdateTest extends PetitionSupport {
         Long caseId = submitBulkCase(CASE_PAYLOAD_PATH, caseWorkerUser).getBody().path("id");
 
         // Hearing Date is a mandatory field that must be set in the future
-        Map<String, Object> updateData = Collections.singletonMap(COURT_HEARING_DATETIME, LocalDateTime.now().plusMonths(3));
+        Map<String, Object> updateData = Collections.singletonMap(COURT_HEARING_DATETIME, LocalDateTime.now().plusMonths(3).toString());
 
         Response cmsResponse = updateBulkCase(updateData,
             caseId,

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/CcdUpdateSupport.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/support/CcdUpdateSupport.java
@@ -39,12 +39,12 @@ public abstract class CcdUpdateSupport extends CcdSubmissionSupport {
             );
     }
 
-    protected Response updateBulkCase(String fileName, Long caseId, String eventId, String userToken) {
+    protected Response updateBulkCase(Map<String, Object> data, Long caseId, String eventId, String userToken) {
         return
             RestUtil.postToRestService(
                 getBulkCaseRequestUrl(caseId, eventId),
                 getHeaders(userToken),
-                fileName == null ? "{}" : loadJson(fileName, PAYLOAD_CONTEXT_PATH)
+                data == null ? "{}" : objectToJson(data)
             );
     }
 


### PR DESCRIPTION
There was a change to the scheduleForListing event used in the failing integration test that triggers a validation callback to check for future court hearing date. This fix adds that field into the test.