### PR TITLE
DIV-5762 - use java chart v2.6.0 and reduced duplicated env references

### DIFF
--- a/charts/div-cms/Chart.yaml
+++ b/charts/div-cms/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Divorce - Case Maintenance Service
 name: div-cms
-version: 1.1.0
+version: 1.2.0

--- a/charts/div-cms/requirements.yaml
+++ b/charts/div-cms/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
     - name: java
-      version: ~2.3.1
+      version: ~2.6.0
       repository: "@hmctspublic"

--- a/charts/div-cms/values.aat.template.yaml
+++ b/charts/div-cms/values.aat.template.yaml
@@ -1,9 +1,6 @@
 java:
     environment:
-        IDAM_CASEWORKER_USERNAME : "DivCaseWorker@AAT.com"
         IDAM_API_BASEURL: "https://idam-api.aat.platform.hmcts.net"
-        MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
-        DOCUMENTATION_SWAGGER_ENABLED: "true"
 
     # Don't modify below here
     image: ${IMAGE_NAME}

--- a/charts/div-cms/values.aat.template.yaml
+++ b/charts/div-cms/values.aat.template.yaml
@@ -1,12 +1,7 @@
 java:
     environment:
-        AUTH_PROVIDER_SERVICE_CLIENT_BASEURL : "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
-        DRAFT_STORE_API_BASEURL : "http://draft-store-service-aat.service.core-compute-aat.internal"
         IDAM_CASEWORKER_USERNAME : "DivCaseWorker@AAT.com"
-        CASE_FORMATTER_SERVICE_API_BASEURL : "http://div-cfs-aat.service.core-compute-aat.internal"
         IDAM_API_BASEURL: "https://idam-api.aat.platform.hmcts.net"
-        IDAM_API_REDIRECT_URL : "https://div-pfe-aat.service.core-compute-aat.internal/authenticated"
-        CASE_DATA_STORE_BASEURL : "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
         MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
         DOCUMENTATION_SWAGGER_ENABLED: "true"
 

--- a/charts/div-cms/values.preview.template.yaml
+++ b/charts/div-cms/values.preview.template.yaml
@@ -1,9 +1,6 @@
 java:
     environment:
-        IDAM_CASEWORKER_USERNAME : "DivCaseWorker@AAT.com"
         IDAM_API_BASEURL: "https://idam-api.aat.platform.hmcts.net"
-        MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
-        DOCUMENTATION_SWAGGER_ENABLED: "true"
 
     # Don't modify below here
     image: ${IMAGE_NAME}

--- a/charts/div-cms/values.preview.template.yaml
+++ b/charts/div-cms/values.preview.template.yaml
@@ -1,12 +1,7 @@
 java:
     environment:
-        AUTH_PROVIDER_SERVICE_CLIENT_BASEURL : "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
-        DRAFT_STORE_API_BASEURL : "http://draft-store-service-aat.service.core-compute-aat.internal"
         IDAM_CASEWORKER_USERNAME : "DivCaseWorker@AAT.com"
-        CASE_FORMATTER_SERVICE_API_BASEURL : "http://div-cfs-aat.service.core-compute-aat.internal"
         IDAM_API_BASEURL: "https://idam-api.aat.platform.hmcts.net"
-        IDAM_API_REDIRECT_URL : "https://div-pfe-aat.service.core-compute-aat.internal/authenticated"
-        CASE_DATA_STORE_BASEURL : "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
         MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
         DOCUMENTATION_SWAGGER_ENABLED: "true"
 

--- a/charts/div-cms/values.yaml
+++ b/charts/div-cms/values.yaml
@@ -1,6 +1,11 @@
 java:
     applicationPort: 4010
     environment:
+        AUTH_PROVIDER_SERVICE_CLIENT_BASEURL: "http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+        DRAFT_STORE_API_BASEURL: "http://draft-store-service-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+        CASE_FORMATTER_SERVICE_API_BASEURL: "http://div-cfs-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+        IDAM_API_REDIRECT_URL: "https://div-pfe-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/authenticated"
+        CASE_DATA_STORE_BASEURL: "http://ccd-data-store-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
         AUTH_PROVIDER_SERVICE_CLIENT_MICROSERVICE: "divorce_ccd_submission"
         REFORM_SERVICE_NAME: "cms"
         REFORM_TEAM: "div"

--- a/charts/div-cms/values.yaml
+++ b/charts/div-cms/values.yaml
@@ -11,6 +11,7 @@ java:
         AUTH_PROVIDER_SERVICE_CLIENT_TOKENTIMETOLIVEINSECONDS: "900"
         LOG_LEVEL: DEBUG
         MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
+        DOCUMENTATION_SWAGGER_ENABLED: true
     keyVaults:
         "div":
             resourceGroup: div

--- a/charts/div-cms/values.yaml
+++ b/charts/div-cms/values.yaml
@@ -1,5 +1,6 @@
 java:
     applicationPort: 4010
+    ingressHost: "div-cms-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     environment:
         AUTH_PROVIDER_SERVICE_CLIENT_BASEURL: "http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
         DRAFT_STORE_API_BASEURL: "http://draft-store-service-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"

--- a/charts/div-cms/values.yaml
+++ b/charts/div-cms/values.yaml
@@ -8,10 +8,9 @@ java:
         IDAM_API_REDIRECT_URL: "https://div-pfe-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/authenticated"
         CASE_DATA_STORE_BASEURL: "http://ccd-data-store-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
         AUTH_PROVIDER_SERVICE_CLIENT_MICROSERVICE: "divorce_ccd_submission"
-        REFORM_SERVICE_NAME: "cms"
-        REFORM_TEAM: "div"
         AUTH_PROVIDER_SERVICE_CLIENT_TOKENTIMETOLIVEINSECONDS: "900"
         LOG_LEVEL: DEBUG
+        MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
     keyVaults:
         "div":
             resourceGroup: div
@@ -19,4 +18,5 @@ java:
                 - ccd-submission-s2s-auth-secret
                 - idam-secret
                 - draft-store-api-encryption-key
+                - idam-caseworker-username
                 - idam-caseworker-password

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -8,4 +8,5 @@ spring:
                 div.ccd-submission-s2s-auth-secret: AUTH_PROVIDER_SERVICE_CLIENT_KEY
                 div.idam-secret: AUTH2_CLIENT_SECRET
                 div.draft-store-api-encryption-key: DRAFT_STORE_API_ENCRYPTION_KEY_VALUE
+                div.idam-caseworker-username: IDAM_CASEWORKER_USERNAME
                 div.idam-caseworker-password: IDAM_CASEWORKER_PASSWORD


### PR DESCRIPTION
# Description

Reduced duplicated config values by moving them to values.yaml
And using {{ .Values.global.environment }} placeholder
Also removed unused env variables (if any)

See 
* https://github.com/hmcts/chart-java/pull/61 
* https://hmcts-reform.slack.com/archives/CLE7A3SKV/p1568286603003800

Fixes #DIV-5762

## Type of change

- [x] New feature (non-breaking change which adds functionality)



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

