### PR TITLE
DIV-5762 - added disableLegacyDeployment() to switch deployment to AKS

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -42,6 +42,7 @@ withPipeline(type , product, component) {
     installCharts()
     enableAksStagingDeployment()
     loadVaultSecrets(secrets)
+    disableLegacyDeployment()
 
     after('checkout') {
         echo '${product}-${component} checked out'

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -40,4 +40,11 @@
         <cve>CVE-2019-14540</cve>
         <cve>CVE-2019-16335</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+            A low severity security issue was reported in the Gradle signing plugin. ]]>
+        </notes>
+        <gav regex="true">.*</gav>
+        <cve>CVE-2019-16370</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION

# Description

This will disable the legacy Azure deployment and switch over the DNS
To the new K8S prod cluster

Fixes #DIV-5762 

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
