### PR TITLE
Apply security fix Fix-CVE-2019-16942 Jackson

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -308,19 +308,6 @@ dependencyManagement {
             entry 'jackson-core'
             entry 'jackson-databind'
         }
-        dependencySet(
-            group: 'com.fasterxml.jackson.datatype',
-            version: versions.jackson
-        ) {
-            entry 'jackson-datatype-jdk8'
-            entry 'jackson-datatype-jsr310'
-        }
-        dependencySet(
-            group: 'com.fasterxml.jackson.module',
-            version: versions.jackson
-        ) {
-            entry 'jackson-module-parameter-names'
-        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,7 @@ def versions = [
     pitest: '1.4.2',
     gradlePitest: '1.3.0',
     sonarPitest: '0.5',
-    jacksonDatabind: '2.9.9.3',
+    jackson: '2.10.0',
     springCloudDependencies: '2.1.0.RELEASE',
     guava: '27.0.1-jre',
     bcpkixJdk15on: '1.60',
@@ -166,7 +166,7 @@ dependencies {
 
     compile group: 'io.github.openfeign', name: 'feign-httpclient', version: versions.feignHttpClient
     compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: versions.reformSpringBootAutoConfigure
-    compile (group: 'com.fasterxml.jackson.core', name:'jackson-databind', version: versions.jacksonDatabind) {
+    compile (group: 'com.fasterxml.jackson.core', name:'jackson-databind', version: versions.jackson) {
         force = true
     }
 
@@ -299,6 +299,27 @@ dependencyManagement {
             entry 'netty-handler'
             entry 'netty-resolver'
             entry 'netty-transport'
+        }
+
+        dependencySet(
+            group: 'com.fasterxml.jackson.core',
+            version: versions.jackson
+        ) {
+            entry 'jackson-core'
+            entry 'jackson-databind'
+        }
+        dependencySet(
+            group: 'com.fasterxml.jackson.datatype',
+            version: versions.jackson
+        ) {
+            entry 'jackson-datatype-jdk8'
+            entry 'jackson-datatype-jsr310'
+        }
+        dependencySet(
+            group: 'com.fasterxml.jackson.module',
+            version: versions.jackson
+        ) {
+            entry 'jackson-module-parameter-names'
         }
     }
 }


### PR DESCRIPTION
Updates Jackson Databind based on [this CVE issue](https://nvd.nist.gov/vuln/detail/CVE-2019-16942)