### PR TITLE
Add previous reasons for divorce mapping to refusal rejection

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CcdCaseProperties.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CcdCaseProperties.java
@@ -26,6 +26,7 @@ public class CcdCaseProperties {
     public static final String D8_DOCUMENTS_GENERATED = "D8DocumentsGenerated";
 
     public static final String PREVIOUS_REASONS_DIVORCE = "PreviousReasonsForDivorce";
+    public static final String PREVIOUS_REASONS_DIVORCE_REFUSAL = "PreviousReasonsForDivorceRefusal";
     public static final String PREVIOUS_ISSUE_DATE = "PreviousIssueDate";
 
     public static final String RESP_SOLICITOR_EMAIL_ADDRESS = "D8RespondentSolicitorEmail";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/DivorceSessionProperties.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/DivorceSessionProperties.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 public class DivorceSessionProperties {
     public static final String PREVIOUS_CASE_ID = "previousCaseId";
     public static final String PREVIOUS_REASONS_FOR_DIVORCE = "previousReasonsForDivorce";
+    public static final String PREVIOUS_REASONS_FOR_DIVORCE_REFUSAL = "previousReasonsForDivorceRefusal";
 
     public static final String LEGAL_PROCEEDINGS = "legalProceedings";
     public static final String DIVORCE_WHO = "divorceWho";

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/PetitionServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/PetitionServiceImpl.java
@@ -206,6 +206,17 @@ public class PetitionServiceImpl implements PetitionService,
     private Map<String, Object> getDraftAmendmentCaseRefusal(CaseDetails oldCase, String authorisation) {
         Map<String, Object> caseData = oldCase.getData();
 
+        List<String> previousReasons = (ArrayList<String>) caseData
+            .get(CcdCaseProperties.PREVIOUS_REASONS_DIVORCE_REFUSAL);
+
+        if (previousReasons == null) {
+            previousReasons = new ArrayList<>();
+        } else {
+            // clone to avoid updating old case
+            previousReasons = new ArrayList<>(previousReasons);
+        }
+        previousReasons.add((String) caseData.get(CcdCaseProperties.D8_REASON_FOR_DIVORCE));
+
         Object issueDateFromOriginalCase = caseData.get(CcdCaseProperties.ISSUE_DATE);
         if (issueDateFromOriginalCase != null) {
             caseData.put(CcdCaseProperties.PREVIOUS_ISSUE_DATE, issueDateFromOriginalCase);
@@ -230,6 +241,7 @@ public class PetitionServiceImpl implements PetitionService,
             .transformToDivorceFormat(caseData, authorisation);
 
         amendmentCaseDraft.put(DivorceSessionProperties.PREVIOUS_CASE_ID, String.valueOf(oldCase.getId()));
+        amendmentCaseDraft.put(DivorceSessionProperties.PREVIOUS_REASONS_FOR_DIVORCE_REFUSAL, previousReasons);
 
         return amendmentCaseDraft;
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/AmendedPetitionForRefusalDraftServiceITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/functionaltest/AmendedPetitionForRefusalDraftServiceITest.java
@@ -47,6 +47,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.TestConstants.TEST_CASE_REF;
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.TestConstants.TEST_DRAFT_DOC_TYPE_DIVORCE_FORMAT;
+import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.TestConstants.TEST_REASON_ADULTERY;
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.TestConstants.TEST_RELATIONSHIP;
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.TestConstants.TEST_SERVICE_TOKEN;
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.TestConstants.TEST_USER_EMAIL;
@@ -133,6 +134,7 @@ public class AmendedPetitionForRefusalDraftServiceITest extends MockSupport {
         caseData.put(CcdCaseProperties.D8_DIVORCE_WHO, TEST_RELATIONSHIP);
         caseData.put(CcdCaseProperties.D8_SCREEN_HAS_MARRIAGE_BROKEN, YES_VALUE);
         caseData.put(CcdCaseProperties.D8_PETITIONER_EMAIL, TEST_USER_EMAIL);
+        caseData.put(CcdCaseProperties.D8_REASON_FOR_DIVORCE, TEST_REASON_ADULTERY);
         caseData.put(REFUSAL_ORDER_REJECTION_REASONS, ImmutableList.of(
             REJECTION_NO_JURISDICTION, REJECTION_NO_CRITERIA, REJECTION_INSUFFICIENT_DETAILS
         ));
@@ -155,6 +157,7 @@ public class AmendedPetitionForRefusalDraftServiceITest extends MockSupport {
         draftData.put(DivorceSessionProperties.DIVORCE_WHO, TEST_RELATIONSHIP);
         draftData.put(DivorceSessionProperties.SCREEN_HAS_MARRIAGE_BROKEN, YES_VALUE);
         draftData.put(DivorceSessionProperties.COURTS, CmsConstants.CTSC_SERVICE_CENTRE);
+        draftData.put(DivorceSessionProperties.PREVIOUS_REASONS_FOR_DIVORCE_REFUSAL, Collections.singletonList(TEST_REASON_ADULTERY));
 
         final CreateDraft createDraft = new CreateDraft(draftData,
             TEST_DRAFT_DOC_TYPE_DIVORCE_FORMAT, maxAge);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/PetitionServiceImplUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/PetitionServiceImplUTest.java
@@ -440,6 +440,7 @@ public class PetitionServiceImplUTest {
         final Map<String, Object> caseData = new HashMap<>();
         caseData.put(ISSUE_DATE, originalCaseIssueDate);
         caseData.put(D8_CASE_REFERENCE, TEST_CASE_ID);
+        caseData.put(D8_REASON_FOR_DIVORCE, TEST_REASON_ADULTERY);
         caseData.put(REFUSAL_ORDER_REJECTION_REASONS, Collections.singletonList("other"));
 
         final CaseDetails caseDetails = CaseDetails.builder().data(caseData)
@@ -447,6 +448,7 @@ public class PetitionServiceImplUTest {
 
         final Map<String, Object> draftData = new HashMap<>();
         draftData.put(DivorceSessionProperties.PREVIOUS_CASE_ID, TEST_CASE_ID);
+        draftData.put(DivorceSessionProperties.PREVIOUS_REASONS_FOR_DIVORCE_REFUSAL, singletonList(TEST_REASON_ADULTERY));
 
         final User user = new User(TEST_AUTH_TOKEN, UserDetails.builder().forename(USER_FIRST_NAME).build());
         when(ccdRetrievalService.retrieveCase(TEST_AUTH_TOKEN, PETITIONER)).thenReturn(caseDetails);
@@ -466,6 +468,7 @@ public class PetitionServiceImplUTest {
     public void givenCaseWasNotIssued_whenCreateAmendedPetitionDraftForRefusal_thenProceedAsExpected() throws DuplicateCaseException {
         final Map<String, Object> caseData = new HashMap<>();
         caseData.put(D8_CASE_REFERENCE, TEST_CASE_ID);
+        caseData.put(D8_REASON_FOR_DIVORCE, TEST_REASON_ADULTERY);
         caseData.put(REFUSAL_ORDER_REJECTION_REASONS, Collections.singletonList("other"));
 
         final CaseDetails caseDetails = CaseDetails.builder().data(caseData)
@@ -473,6 +476,7 @@ public class PetitionServiceImplUTest {
 
         final Map<String, Object> draftData = new HashMap<>();
         draftData.put(DivorceSessionProperties.PREVIOUS_CASE_ID, TEST_CASE_ID);
+        draftData.put(DivorceSessionProperties.PREVIOUS_REASONS_FOR_DIVORCE_REFUSAL, singletonList(TEST_REASON_ADULTERY));
 
         final User user = new User(TEST_AUTH_TOKEN, UserDetails.builder().forename(USER_FIRST_NAME).build());
         when(ccdRetrievalService.retrieveCase(TEST_AUTH_TOKEN, PETITIONER)).thenReturn(caseDetails);
@@ -530,6 +534,7 @@ public class PetitionServiceImplUTest {
         final Map<String, Object> draftData = new HashMap<>();
 
         draftData.put(DivorceSessionProperties.PREVIOUS_CASE_ID, TEST_CASE_ID);
+        draftData.put(DivorceSessionProperties.PREVIOUS_REASONS_FOR_DIVORCE_REFUSAL, singletonList(TEST_REASON_ADULTERY));
 
         final User user = new User(TEST_AUTH_TOKEN, UserDetails.builder().forename(USER_FIRST_NAME).build());
 
@@ -567,6 +572,7 @@ public class PetitionServiceImplUTest {
         final Map<String, Object> draftData = new HashMap<>();
 
         draftData.put(DivorceSessionProperties.PREVIOUS_CASE_ID, TEST_CASE_ID);
+        draftData.put(DivorceSessionProperties.PREVIOUS_REASONS_FOR_DIVORCE_REFUSAL, singletonList(TEST_REASON_ADULTERY));
 
         final User user = new User(TEST_AUTH_TOKEN, UserDetails.builder().forename(USER_FIRST_NAME).build());
 
@@ -604,6 +610,7 @@ public class PetitionServiceImplUTest {
         final Map<String, Object> draftData = new HashMap<>();
 
         draftData.put(DivorceSessionProperties.PREVIOUS_CASE_ID, TEST_CASE_ID);
+        draftData.put(DivorceSessionProperties.PREVIOUS_REASONS_FOR_DIVORCE_REFUSAL, singletonList(TEST_REASON_ADULTERY));
 
         final User user = new User(TEST_AUTH_TOKEN, UserDetails.builder().forename(USER_FIRST_NAME).build());
 
@@ -629,9 +636,10 @@ public class PetitionServiceImplUTest {
 
         final Map<String, Object> caseData = new HashMap<>();
         caseData.put(D8_CASE_REFERENCE, TEST_CASE_REF);
-        caseData.put(REFUSAL_ORDER_REJECTION_REASONS, ImmutableList.of(
+        List<String> refusalRejectionReasons = ImmutableList.of(
             REJECTION_NO_JURISDICTION, REJECTION_NO_CRITERIA, REJECTION_INSUFFICIENT_DETAILS
-        ));
+        );
+        caseData.put(REFUSAL_ORDER_REJECTION_REASONS, refusalRejectionReasons);
         // Case Data to Keep
         caseData.put(D_8_DIVORCE_WHO, TEST_RELATIONSHIP);
         // Case Data to be Removed
@@ -643,6 +651,7 @@ public class PetitionServiceImplUTest {
         final Map<String, Object> draftData = new HashMap<>();
 
         draftData.put(DivorceSessionProperties.PREVIOUS_CASE_ID, TEST_CASE_ID);
+        draftData.put(DivorceSessionProperties.PREVIOUS_REASONS_FOR_DIVORCE_REFUSAL, singletonList(TEST_REASON_ADULTERY));
 
         final User user = new User(TEST_AUTH_TOKEN, UserDetails.builder().forename(USER_FIRST_NAME).build());
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DIV-5784

Adds previous reasons for divorce refusal field to draft (not using the existing field as that removes the option from being selectable from frontend)