### PR TITLE
Add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,5 @@
+version: 1
+update_configs:
+  - package_manager: "java:gradle"
+    directory: "/"
+    update_schedule: "daily"


### PR DESCRIPTION

# Description

This is to add dependabot so that it upgrades the springboot health starter to version 0.0.5 which is recommended for AKS changes being made.