### PR TITLE
Regression test for ccd15

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -11,7 +11,7 @@ properties([
     ])
 ])
 
-@Library("Infrastructure")
+@Library("Infrastructure@helm2.16.1")
 
 def type = "java"
 def product = "div"

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -11,7 +11,7 @@ properties([
     ])
 ])
 
-@Library("Infrastructure@helm2.16.1")
+@Library("Infrastructure")
 
 def type = "java"
 def product = "div"

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdAccessServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdAccessServiceImpl.java
@@ -162,7 +162,7 @@ public class CcdAccessServiceImpl extends BaseCcdCaseService implements CcdAcces
         }
         final String emailAddressAssignedToCase = (String) caseData.get(emailField);
 
-        if (emailAddressAssignedToCase == null) {
+        if (emailAddressAssignedToCase == null || emailAddressAssignedToCase.trim().isEmpty()) {
             log.info("Case {} has not been been assigned a {} yet.", caseId, respondentType);
             final String petitionerEmail = (String) caseData.get(D8_PETITIONER_EMAIL);
 
@@ -196,6 +196,10 @@ public class CcdAccessServiceImpl extends BaseCcdCaseService implements CcdAcces
         final String respondentSolicitorCompany = (String) caseData.get(D8_RESPONDENT_SOLICITOR_COMPANY);
 
         return YES_VALUE.equalsIgnoreCase(respondentSolicitorRepresented)
-            || respondentSolicitorName != null && respondentSolicitorCompany != null;
+            || !isEmpty(respondentSolicitorName) && !isEmpty(respondentSolicitorCompany);
+    }
+
+    private boolean isEmpty(String value) {
+        return value == null || value.trim().isEmpty();
     }
 }


### PR DESCRIPTION
# Description

Added and used a isEmpty() method to handle empty string values on solicitor details.

Fixes [RPET-11](https://tools.hmcts.net/jira/browse/RPET-11)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests added

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
