### PR TITLE
isEmpty function added to handle empty string values on solicitor details

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdAccessServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdAccessServiceImpl.java
@@ -162,7 +162,7 @@ public class CcdAccessServiceImpl extends BaseCcdCaseService implements CcdAcces
         }
         final String emailAddressAssignedToCase = (String) caseData.get(emailField);
 
-        if (emailAddressAssignedToCase == null) {
+        if (isEmpty(emailAddressAssignedToCase)) {
             log.info("Case {} has not been been assigned a {} yet.", caseId, respondentType);
             final String petitionerEmail = (String) caseData.get(D8_PETITIONER_EMAIL);
 
@@ -196,6 +196,10 @@ public class CcdAccessServiceImpl extends BaseCcdCaseService implements CcdAcces
         final String respondentSolicitorCompany = (String) caseData.get(D8_RESPONDENT_SOLICITOR_COMPANY);
 
         return YES_VALUE.equalsIgnoreCase(respondentSolicitorRepresented)
-            || respondentSolicitorName != null && respondentSolicitorCompany != null;
+            || !isEmpty(respondentSolicitorName) && !isEmpty(respondentSolicitorCompany);
+    }
+
+    private boolean isEmpty(String value) {
+        return value == null || value.trim().isEmpty();
     }
 }


### PR DESCRIPTION

# Description

Added and used a isEmpty() method to handle empty string values on solicitor details.

Fixes [RPET-11](https://tools.hmcts.net/jira/browse/RPET-11)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests added.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
