### PR TITLE
Cleanup API

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/client/DraftStoreClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/client/DraftStoreClient.java
@@ -1,8 +1,13 @@
 package uk.gov.hmcts.reform.divorce.casemaintenanceservice.client;
 
+import io.swagger.annotations.ApiOperation;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,51 +25,41 @@ public interface DraftStoreClient {
     String SERVICE_AUTHORIZATION_HEADER_NAME = "ServiceAuthorization";
     String SECRET_HEADER_NAME = "Secret";
 
-    @RequestMapping(
-        method = RequestMethod.GET,
-        value = "/drafts",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Return all draft cases")
+    @GetMapping(value = "/drafts",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     DraftList getAllDrafts(@RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation,
                            @RequestHeader(SERVICE_AUTHORIZATION_HEADER_NAME) String serviceAuthorisation,
                            @RequestHeader(SECRET_HEADER_NAME) String secret);
 
-    @RequestMapping(
-        method = RequestMethod.GET,
-        value = "/drafts",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Return all draft cases")
+    @GetMapping(value = "/drafts",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     DraftList getAllDrafts(@RequestParam("after") String after,
                            @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation,
                            @RequestHeader(SERVICE_AUTHORIZATION_HEADER_NAME) String serviceAuthorisation,
                            @RequestHeader(SECRET_HEADER_NAME) String secret);
 
-    @RequestMapping(
-        method = RequestMethod.POST,
-        value = "/drafts",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Create single draft case")
+    @PostMapping(value = "/drafts",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     void createSingleDraft(@RequestBody CreateDraft draft,
                                 @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation,
                                 @RequestHeader(SERVICE_AUTHORIZATION_HEADER_NAME) String serviceAuthorisation,
                                 @RequestHeader(SECRET_HEADER_NAME) String secret);
 
-    @RequestMapping(
-        method = RequestMethod.PUT,
-        value = "/drafts/{draftId}",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Update existing divorce session draft")
+    @PutMapping(value = "/drafts/{draftId}",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     void updateSingleDraft(@PathVariable("draftId") String draftId,
                                 @RequestBody UpdateDraft draft,
                                 @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation,
                                 @RequestHeader(SERVICE_AUTHORIZATION_HEADER_NAME) String serviceAuthorisation,
                                 @RequestHeader(SECRET_HEADER_NAME) String secret);
 
-    @RequestMapping(
-        method = RequestMethod.DELETE,
-        value = "/drafts",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
+    @ApiOperation("Delete all divorce session drafts")
+    @DeleteMapping(value = "/drafts",
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
     void deleteAllDrafts(@RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation,
                          @RequestHeader(SERVICE_AUTHORIZATION_HEADER_NAME) String serviceAuthorisation);
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/client/FormatterServiceClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/client/FormatterServiceClient.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.divorce.casemaintenanceservice.client;
 
+import io.swagger.annotations.ApiOperation;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,17 +15,20 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 @FeignClient(name = "formatter-service-client", url = "${case.formatter.service.api.baseurl}")
 public interface FormatterServiceClient {
 
+
+    @ApiOperation("Transform to CCD Format")
     @PostMapping(
         value = "caseformatter/version/1/to-ccd-format",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
-    Map<String, Object> transformToCCDFormat(@RequestBody Object data,
-                                             @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation);
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
+    Map<String, Object> transformToCCDFormat(
+        @RequestBody Object data,
+        @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation);
 
+    @ApiOperation("Transform to Divorce Format")
     @PostMapping(
         value = "caseformatter/version/1/to-divorce-format",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
-    )
-    Map<String, Object> transformToDivorceFormat(@RequestBody Object data,
-                                             @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation);
+        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
+    Map<String, Object> transformToDivorceFormat(
+        @RequestBody Object data,
+        @RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation);
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/CcdController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/CcdController.java
@@ -7,7 +7,6 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,6 +25,8 @@ import uk.gov.hmcts.reform.divorce.casemaintenanceservice.service.CcdUpdateServi
 
 import java.util.Map;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 @RestController
 @RequestMapping(path = "casemaintenance/version/1")
 @Api(value = "Case Maintenance Services", consumes = "application/json", produces = "application/json")
@@ -42,42 +43,43 @@ public class CcdController {
     @Autowired
     private CcdRetrievalService ccdRetrievalService;
 
-    @PostMapping(path = "/submit", consumes = MediaType.APPLICATION_JSON_VALUE,
-        produces = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(path = "/submit", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Submits a divorce session to CCD")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "Case Data was submitted to CCD. The body payload returns the complete "
-            + "case back", response = CaseDetails.class)
+        @ApiResponse(code = 200,
+            message = "Case Data was submitted to CCD. The body payload returns the complete case back",
+            response = CaseDetails.class)
         }
     )
     public ResponseEntity<CaseDetails> submitCase(
         @RequestBody @ApiParam(value = "Case Data", required = true) Map<String, Object> data,
-        @RequestHeader("Authorization")
+        @RequestHeader(HttpHeaders.AUTHORIZATION)
         @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String jwt) {
         return ResponseEntity.ok(ccdSubmissionService.submitCase(data, jwt));
     }
 
-    @PostMapping(path = "/bulk/submit", consumes = MediaType.APPLICATION_JSON_VALUE,
-        produces = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(path = "/bulk/submit", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Submits a divorce session to CCD")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "Case Data was submitted to CCD. The body payload returns the complete "
-            + "case back", response = CaseDetails.class)
+        @ApiResponse(code = 200,
+            message = "Case Data was submitted to CCD. The body payload returns the complete case back",
+            response = CaseDetails.class)
         }
     )
     public ResponseEntity<CaseDetails> submitBulkCase(
         @RequestBody @ApiParam(value = "Bulk case data", required = true) Map<String, Object> data,
-        @RequestHeader("Authorization")
+        @RequestHeader(HttpHeaders.AUTHORIZATION)
         @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String jwt) {
         return ResponseEntity.ok(ccdSubmissionService.submitBulkCase(data, jwt));
     }
 
-    @PostMapping(path = "/updateCase/{caseId}/{eventId}", consumes = MediaType.APPLICATION_JSON_VALUE,
-        produces = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(path = "/updateCase/{caseId}/{eventId}", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Updates case details")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "A request to update the case details was sent to CCD. The body payload "
-            + "will return the latest version of the case after the update.", response = CaseDetails.class)
+        @ApiResponse(code = 200,
+            message = "A request to update the case details was sent to CCD. The body payload "
+            + "will return the latest version of the case after the update.",
+            response = CaseDetails.class)
         }
     )
     public ResponseEntity<CaseDetails> updateCase(
@@ -85,17 +87,18 @@ public class CcdController {
         @RequestBody
         @ApiParam(value = "The update event that requires the resubmission to CCD", required = true) Object data,
         @PathVariable("eventId") @ApiParam(value = "Update Event Type Id", required = true) String eventId,
-        @RequestHeader("Authorization")
+        @RequestHeader(HttpHeaders.AUTHORIZATION)
         @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String jwt) {
         return ResponseEntity.ok(ccdUpdateService.update(caseId, data, eventId, jwt));
     }
 
-    @PostMapping(path = "/bulk/updateCase/{caseId}/{eventId}", consumes = MediaType.APPLICATION_JSON_VALUE,
-        produces = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(path = "/bulk/updateCase/{caseId}/{eventId}", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Updates bulk case details")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "A request to update the bulk case details was sent to CCD. The body payload "
-            + "will return the latest version of the case after the update.", response = CaseDetails.class)
+        @ApiResponse(code = 200,
+            message = "A request to update the bulk case details was sent to CCD. The body payload "
+            + "will return the latest version of the case after the update.",
+            response = CaseDetails.class)
         }
     )
     public ResponseEntity<CaseDetails> updateBulkCase(
@@ -103,7 +106,7 @@ public class CcdController {
         @RequestBody
         @ApiParam(value = "The update event that requires the resubmission to CCD", required = true) Object data,
         @PathVariable("eventId") @ApiParam(value = "Update Event Type Id", required = true) String eventId,
-        @RequestHeader("Authorization")
+        @RequestHeader(HttpHeaders.AUTHORIZATION)
         @ApiParam(value = "JWT authorisation token issued by IDAM", required = true) final String jwt) {
         return ResponseEntity.ok(ccdUpdateService.updateBulkCase(caseId, data, eventId, jwt));
     }
@@ -118,7 +121,7 @@ public class CcdController {
         }
     )
     public ResponseEntity<Void> linkRespondent(
-        @RequestHeader("Authorization")
+        @RequestHeader(HttpHeaders.AUTHORIZATION)
         @ApiParam(value = "JWT authorisation token of the respondent", required = true) final String authToken,
         @PathVariable("caseId") @ApiParam("Unique identifier of the session that was submitted to CCD") String caseId,
         @PathVariable("letterHolderId")
@@ -132,13 +135,12 @@ public class CcdController {
     @DeleteMapping(path = "/link-respondent/{caseId}")
     @ApiOperation(value = "Removes user permission on a case")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "Returned when case with id exists and the access is "
-            + "removed to the respondent user"),
+        @ApiResponse(code = 200, message = "Returned when case with id exists and the access is removed to the respondent user"),
         @ApiResponse(code = 404, message = "Returned when case with id not found"),
         }
     )
     public ResponseEntity<Void> unlinkRespondent(
-        @RequestHeader("Authorization")
+        @RequestHeader(HttpHeaders.AUTHORIZATION)
         @ApiParam(value = "JWT authorisation token of the respondent", required = true) final String authToken,
         @PathVariable("caseId") @ApiParam("Unique identifier of the session that was submitted to CCD") String caseId) {
 
@@ -147,7 +149,7 @@ public class CcdController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping(path = "/search", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(path = "/search", produces = APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Retrieve CCD case by CaseId")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "Returns list of cases based on search criteria"),
@@ -161,7 +163,7 @@ public class CcdController {
         return ResponseEntity.ok(ccdRetrievalService.searchCase(jwt, query));
     }
 
-    @PutMapping(path = "/add-petitioner-solicitor-role/{caseId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PutMapping(path = "/add-petitioner-solicitor-role/{caseId}", produces = APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Assign the role of [PETSOLICITOR] for user and case")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "Role of [PETSOLICITOR] was added to the given case"),

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/management/monitoring/health/DefaultHttpEntityFactory.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/management/monitoring/health/DefaultHttpEntityFactory.java
@@ -12,7 +12,7 @@ public class DefaultHttpEntityFactory implements HttpEntityFactory {
     @Override
     public HttpEntity<Object> createRequestEntityForHealthCheck() {
         HttpHeaders headers = new HttpHeaders();
-        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON_UTF8));
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
 
         return new HttpEntity<>(headers);
     }


### PR DESCRIPTION
Added @ApiOperation() to all endpoints with a description of what the endpoint does to make out API more clear
Replaced "@RequestMapping()" with action specific annotation. For example: "method = POST, value = "/dn-submitted")
- Replace deprecated "APPLICATION_JSON_UTF8" with proper APPLICATION_JSON