### PR TITLE
feature: Add test retries to the IntegrationTest class

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/RetryRule.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/RetryRule.java
@@ -1,0 +1,50 @@
+package uk.gov.hmcts.reform.divorce;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+@Slf4j
+public class RetryRule implements TestRule {
+    private static final int MAX_RETRIES = 30;
+    private static int totalRetries = 0;
+    private int retryCount;
+
+    public RetryRule(int retryCount) {
+        this.retryCount = retryCount;
+    }
+
+    public Statement apply(Statement base, Description description) {
+        return statement(base, description);
+    }
+
+    private Statement statement(final Statement base, final Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                Throwable caughtThrowable = null;
+                int failCount = 0;
+
+                for (int i = 0; i < retryCount; i++) {
+                    try {
+                        base.evaluate();
+                        return;
+                    } catch (Throwable t) {
+                        caughtThrowable = t;
+                        failCount++;
+                        log.error("{} run {} failed. - {}", description.getDisplayName(), (i + 1), t.getMessage());
+                        if (totalRetries >= MAX_RETRIES) {
+                            log.warn("Maximum retry limit across test suite exceeded (max. {}): not retrying failed test.", MAX_RETRIES);
+                            break;
+                        } else {
+                            totalRetries++;
+                        }
+                    }
+                }
+                log.error("{}: giving up after {} failures.", description.getDisplayName(), failCount);
+                throw caughtThrowable;
+            }
+        };
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/context/IntegrationTest.java
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.ContextConfiguration;
+import uk.gov.hmcts.reform.divorce.RetryRule;
 import uk.gov.hmcts.reform.divorce.model.UserDetails;
 import uk.gov.hmcts.reform.divorce.support.IdamTestSupport;
 
@@ -33,6 +34,9 @@ public abstract class IntegrationTest {
 
     @Rule
     public SpringIntegrationMethodRule springMethodIntegration;
+
+    @Rule
+    public RetryRule retryRule = new RetryRule(3);
 
     protected IntegrationTest() {
         this.springMethodIntegration = new SpringIntegrationMethodRule();


### PR DESCRIPTION
# Description

This change adds RetryRule to the IntegrationTest class to rerun flakey Functional API test-runs in AAT, to help improve build pipeline stability and reduce the impact from other services in the test environment. Max number of tries is set at 3 and has a cut-off at 30 retries, so that if a common component like IDAM is down it won't hog build resources retrying unnecessarily.

Note: This has been found to improve stability in Case Orchestration Service.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
