### PR TITLE
DIV-6653: Allow respondent to query cases from given new states

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CaseRetrievalStateMap.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CaseRetrievalStateMap.java
@@ -5,7 +5,6 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -61,7 +60,12 @@ public class CaseRetrievalStateMap {
 
     public static final Map<CaseStateGrouping, List<CaseState>> RESPONDENT_CASE_STATE_GROUPING =
         ImmutableMap.of(
-            CaseStateGrouping.INCOMPLETE, Collections.singletonList(CaseState.AOS_STARTED),
+            CaseStateGrouping.INCOMPLETE, Arrays.asList(
+                CaseState.AOS_STARTED,
+                CaseState.AWAITING_ALTERNATIVE_SERVICE,
+                CaseState.AWAITING_PROCESS_SERVER_SERVICE,
+                CaseState.AWAITING_DWP_RESPONSE
+            ),
             CaseStateGrouping.COMPLETE, Arrays.asList(
                 CaseState.SUBMITTED,
                 CaseState.ISSUED,

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CaseRetrievalStateMapTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CaseRetrievalStateMapTest.java
@@ -62,7 +62,10 @@ public class CaseRetrievalStateMapTest {
     public void respondentCaseStateGroupingStateTest() {
         assertThat(RESPONDENT_CASE_STATE_GROUPING.get(CaseStateGrouping.INCOMPLETE))
             .contains(
-                CaseState.AOS_STARTED
+                CaseState.AOS_STARTED,
+                CaseState.AWAITING_ALTERNATIVE_SERVICE,
+                CaseState.AWAITING_PROCESS_SERVER_SERVICE,
+                CaseState.AWAITING_DWP_RESPONSE
             );
 
         assertThat(RESPONDENT_CASE_STATE_GROUPING.get(CaseStateGrouping.COMPLETE))


### PR DESCRIPTION
# Description

Allow respondent to query cases from given new states:

- AwaitingAlternativeService
- AwaitingProcessServerService
- AwaitingDWPResponse

Fixes https://tools.hmcts.net/jira/browse/DIV-6653

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit test modified

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
