### PR TITLE
DIV-6654: Map general referral states on Petitioner and Respondent apps

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/ApplicationStatus.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/ApplicationStatus.java
@@ -42,6 +42,8 @@ public enum ApplicationStatus {
     AWAITING_ALTERNATIVE_SERVICE("AwaitingAlternativeService"),
     AWAITING_PROCESS_SERVER_SERVICE("AwaitingProcessServerService"),
     AWAITING_DWP_RESPONSE("AwaitingDWPResponse"),
+    AWAITING_GENERAL_REFERRAL_PAYMENT("AwaitingGeneralReferralPayment"),
+    GENERAL_CONSIDERATION_COMPLETE("GeneralConsiderationComplete"),
     UNKNOWN("DNCompleted");
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CaseRetrievalStateMap.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CaseRetrievalStateMap.java
@@ -50,7 +50,9 @@ public class CaseRetrievalStateMap {
                 CaseState.SERVICE_APPLICATION_NOT_APPROVED,
                 CaseState.AWAITING_ALTERNATIVE_SERVICE,
                 CaseState.AWAITING_PROCESS_SERVER_SERVICE,
-                CaseState.AWAITING_DWP_RESPONSE
+                CaseState.AWAITING_DWP_RESPONSE,
+                CaseState.AWAITING_GENERAL_REFERRAL_PAYMENT,
+                CaseState.GENERAL_CONSIDERATION_COMPLETE
             ),
             CaseStateGrouping.AMEND, Arrays.asList(
                 CaseState.AMEND_PETITION,
@@ -94,7 +96,9 @@ public class CaseRetrievalStateMap {
                 CaseState.AOS_AWAITING_SOL,
                 CaseState.CLARIFICATION_SUBMITTED,
                 CaseState.AWAITING_ADMIN_CLARIFICATION,
-                CaseState.SERVICE_APPLICATION_NOT_APPROVED)
+                CaseState.SERVICE_APPLICATION_NOT_APPROVED,
+                CaseState.AWAITING_GENERAL_REFERRAL_PAYMENT,
+                CaseState.GENERAL_CONSIDERATION_COMPLETE)
         );
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CaseState.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CaseState.java
@@ -47,6 +47,8 @@ public enum CaseState {
     AWAITING_ALTERNATIVE_SERVICE("AwaitingAlternativeService", ApplicationStatus.AWAITING_ALTERNATIVE_SERVICE),
     AWAITING_PROCESS_SERVER_SERVICE("AwaitingProcessServerService", ApplicationStatus.AWAITING_PROCESS_SERVER_SERVICE),
     AWAITING_DWP_RESPONSE("AwaitingDWPResponse", ApplicationStatus.AWAITING_DWP_RESPONSE),
+    AWAITING_GENERAL_REFERRAL_PAYMENT("AwaitingGeneralReferralPayment", ApplicationStatus.AWAITING_GENERAL_REFERRAL_PAYMENT),
+    GENERAL_CONSIDERATION_COMPLETE("GeneralConsiderationComplete", ApplicationStatus.GENERAL_CONSIDERATION_COMPLETE),
     UNKNOWN("Unknown", ApplicationStatus.UNKNOWN);
 
     private final String value;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CaseRetrievalStateMapTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CaseRetrievalStateMapTest.java
@@ -48,7 +48,9 @@ public class CaseRetrievalStateMapTest {
                 CaseState.SERVICE_APPLICATION_NOT_APPROVED,
                 CaseState.AWAITING_ALTERNATIVE_SERVICE,
                 CaseState.AWAITING_PROCESS_SERVER_SERVICE,
-                CaseState.AWAITING_DWP_RESPONSE
+                CaseState.AWAITING_DWP_RESPONSE,
+                CaseState.AWAITING_GENERAL_REFERRAL_PAYMENT,
+                CaseState.GENERAL_CONSIDERATION_COMPLETE
             );
 
         assertThat(PETITIONER_CASE_STATE_GROUPING.get(CaseStateGrouping.AMEND))
@@ -94,7 +96,9 @@ public class CaseRetrievalStateMapTest {
                 CaseState.DN_DRAFTED,
                 CaseState.CLARIFICATION_SUBMITTED,
                 CaseState.AWAITING_ADMIN_CLARIFICATION,
-                CaseState.SERVICE_APPLICATION_NOT_APPROVED
+                CaseState.SERVICE_APPLICATION_NOT_APPROVED,
+                CaseState.AWAITING_GENERAL_REFERRAL_PAYMENT,
+                CaseState.GENERAL_CONSIDERATION_COMPLETE
             );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CaseStateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CaseStateTest.java
@@ -53,7 +53,9 @@ public class CaseStateTest {
                 {"Unknown", "DNCompleted"},
                 {"DaRequested", "DARequested"},
                 {"ClarificationSubmitted", "ClarificationSubmitted"},
-                {"AwaitingAdminClarification", "AwaitingAdminClarification"}
+                {"AwaitingAdminClarification", "AwaitingAdminClarification"},
+                {"AwaitingGeneralReferralPayment", "AwaitingGeneralReferralPayment"},
+                {"GeneralConsiderationComplete", "GeneralConsiderationComplete"}
         });
     }
 


### PR DESCRIPTION
# Description

https://tools.hmcts.net/jira/browse/DIV-6654

Adding cases that are in `AwaitingGeneralReferralPayment` and `GeneralConsiderationComplete` state to the list of cases returned by the service.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
