### PR TITLE
DIV-6228: Citizen Respondent submit AOS response whilst bailiff application in progress

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/ApplicationStatus.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/ApplicationStatus.java
@@ -18,6 +18,7 @@ public enum ApplicationStatus {
     AWAITING_ALTERNATIVE_SERVICE("AwaitingAlternativeService"),
     AWAITING_AMEND_CASE("AwaitingAmendCase"),
     AWAITING_BAILIFF_SERVICE("AwaitingBailiffService"),
+    AWAITING_BAILIFF_REFERRAL("AwaitingBailiffReferral"),
     AWAITING_CLARIFICATION("AwaitingClarification"),
     AWAITING_CONSIDERATION("AwaitingConsideration"),
     AWAITING_CONSIDERATION_DN("AwaitingConsiderationDN"),

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CaseRetrievalStateMap.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CaseRetrievalStateMap.java
@@ -101,7 +101,10 @@ public class CaseRetrievalStateMap {
                 CaseState.AWAITING_ADMIN_CLARIFICATION,
                 CaseState.SERVICE_APPLICATION_NOT_APPROVED,
                 CaseState.AWAITING_GENERAL_REFERRAL_PAYMENT,
-                CaseState.GENERAL_CONSIDERATION_COMPLETE)
+                CaseState.GENERAL_CONSIDERATION_COMPLETE,
+                CaseState.AWAITING_BAILIFF_REFERRAL,
+                CaseState.AWAITING_BAILIFF_SERVICE,
+                CaseState.ISSUED_TO_BAILIFF)
         );
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CaseState.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CaseState.java
@@ -18,6 +18,7 @@ public enum CaseState {
     AOS_SUBMITTED_AWAITING_ANSWER("AosSubmittedAwaitingAnswer", ApplicationStatus.AOS_SUBMITTED_AWAITING_ANSWER),
     AWAITING_ADMIN_CLARIFICATION("AwaitingAdminClarification", ApplicationStatus.AWAITING_ADMIN_CLARIFICATION),
     AWAITING_BAILIFF_SERVICE("AwaitingBailiffService", ApplicationStatus.AWAITING_BAILIFF_SERVICE),
+    AWAITING_BAILIFF_REFERRAL("AwaitingBailiffReferral", ApplicationStatus.AWAITING_BAILIFF_REFERRAL),
     AWAITING_ALTERNATIVE_SERVICE("AwaitingAlternativeService", ApplicationStatus.AWAITING_ALTERNATIVE_SERVICE),
     AWAITING_AMEND_CASE("AwaitingAmendCase", ApplicationStatus.AWAITING_AMEND_CASE),
     AWAITING_CLARIFICATION("AwaitingClarification", ApplicationStatus.AWAITING_CLARIFICATION),

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/CcdControllerUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/controller/CcdControllerUTest.java
@@ -18,9 +18,9 @@ import uk.gov.hmcts.reform.divorce.casemaintenanceservice.service.CcdUpdateServi
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CaseRetrievalStateMapTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CaseRetrievalStateMapTest.java
@@ -99,7 +99,10 @@ public class CaseRetrievalStateMapTest {
                 CaseState.AWAITING_ADMIN_CLARIFICATION,
                 CaseState.SERVICE_APPLICATION_NOT_APPROVED,
                 CaseState.AWAITING_GENERAL_REFERRAL_PAYMENT,
-                CaseState.GENERAL_CONSIDERATION_COMPLETE
+                CaseState.GENERAL_CONSIDERATION_COMPLETE,
+                CaseState.AWAITING_BAILIFF_REFERRAL,
+                CaseState.AWAITING_BAILIFF_SERVICE,
+                CaseState.ISSUED_TO_BAILIFF
             );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CaseRetrievalStateMapTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/domain/model/CaseRetrievalStateMapTest.java
@@ -51,7 +51,8 @@ public class CaseRetrievalStateMapTest {
                 CaseState.AWAITING_PROCESS_SERVER_SERVICE,
                 CaseState.AWAITING_DWP_RESPONSE,
                 CaseState.AWAITING_GENERAL_REFERRAL_PAYMENT,
-                CaseState.GENERAL_CONSIDERATION_COMPLETE
+                CaseState.GENERAL_CONSIDERATION_COMPLETE,
+                CaseState.ISSUED_TO_BAILIFF
             );
 
         assertThat(PETITIONER_CASE_STATE_GROUPING.get(CaseStateGrouping.AMEND))

--- a/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdRetrievalServiceImplUTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/casemaintenanceservice/service/impl/CcdRetrievalServiceImplUTest.java
@@ -25,10 +25,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.divorce.casemaintenanceservice.TestConstants.TEST_AUTHORISATION;


### PR DESCRIPTION
# Description
https://tools.hmcts.net/jira/browse/DIV-6228

Adding to the list of cases that are returned to RFE to include these states 

1. AwaitingBailiffReferral
2. AwaitingBailiffService
3. IssuedToBailiff

to make it possible for the respondent or co-respondent to progress with an application if the bailiff process has already began.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
