### PR TITLE
Fix terraform instance_size error

### DIFF
--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -4,7 +4,7 @@ terraform {
     required_providers {
         azurerm = {
             source  = "hashicorp/azurerm"
-            version = "3.79.0"
+            version = "3.96.0"
         }
         random = {
             source = "hashicorp/random"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -12,6 +12,10 @@ variable "capacity" {
   default = "1"
 }
 
+variable "instance_size" {
+    default = "I2"
+}
+
 variable "vault_env" {}
 
 variable "common_tags" {

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -16,6 +16,10 @@ variable "instance_size" {
     default = "I2"
 }
 
+variable "health_check_ttl" {
+    default = "4000"
+}
+
 variable "vault_env" {}
 
 variable "common_tags" {


### PR DESCRIPTION
# Description

Fix terraform error encountered during pipeline execution

```
14:15:31  Planning failed. Terraform encountered an error while generating this plan.
14:15:31  
14:15:31  Warning: Value for undeclared variable
14:15:31  
14:15:31  The root module does not declare a variable named "instance_size" but a
14:15:31  value was found in file "aat.tfvars". If you meant to use this value, add a
14:15:31  "variable" block to the configuration.
```

